### PR TITLE
Suite-Sparse: version 4.4.4.

### DIFF
--- a/octave.rb
+++ b/octave.rb
@@ -5,7 +5,7 @@ class Octave < Formula
   mirror "https://ftp.gnu.org/gnu/octave/octave-3.8.2.tar.bz2"
   sha256 "83bbd701aab04e7e57d0d5b8373dd54719bebb64ce0a850e69bf3d7454f33bae"
   head "http://www.octave.org/hg/octave", :branch => "default", :using => :hg
-  revision 1
+  revision 2
 
   stable do
     # Allows clang 3.5 to compile with a recent libc++ release.
@@ -59,7 +59,7 @@ class Octave < Formula
   option "without-hdf5",           "Do not use HDF5 (hdf5 data file support)"
   option "without-qhull",          "Do not use the Qhull library (delaunay,voronoi,etc.)"
   option "without-qrupdate",       "Do not use the QRupdate package (qrdelete,qrinsert,qrshift,qrupdate)"
-  option "without-suite-sparse",   "Do not use SuiteSparse (sparse matrix operations)"
+  option "without-suite-sparse421", "Do not use SuiteSparse (sparse matrix operations)"
   option "without-zlib",           "Do not use zlib (compressed MATLAB file formats)"
 
   depends_on :fortran
@@ -94,7 +94,7 @@ class Octave < Formula
   depends_on :java            => :recommended
 
   depends_on "gnuplot"       => [:recommended, build.with?("gui") ? "with-qt" : ""]
-  depends_on "suite-sparse"   => :recommended
+  depends_on "suite-sparse421" => :recommended
   depends_on "readline"       => :recommended
   depends_on "arpack"         => :recommended
   depends_on "fftw"           => :recommended
@@ -132,7 +132,7 @@ class Octave < Formula
     args << "--without-qhull"    if build.without? "qhull"
     args << "--without-qrupdate" if build.without? "qrupdate"
 
-    if build.without? "suite-sparse"
+    if build.without? "suite-sparse421"
       args << "--without-amd"
       args << "--without-camd"
       args << "--without-colamd"
@@ -142,7 +142,7 @@ class Octave < Formula
       args << "--without-cholmod"
       args << "--without-umfpack"
     else
-      sparse = Tab.for_name("suite-sparse")
+      sparse = Tab.for_name("suite-sparse421")
       ENV.append_to_cflags "-L#{Formula["metis4"].opt_lib} -lmetis" if sparse.with? "metis4"
     end
 
@@ -241,7 +241,7 @@ class Octave < Formula
             --------
             These failures indicate a conflict between Octave and its BLAS-related
             dependencies. You can likely correct these by removing and reinstalling
-            arpack, qrupdate, suite-sparse, and octave. Please use the same BLAS
+            arpack, qrupdate, suite-sparse421, and octave. Please use the same BLAS
             settings for all (i.e., with the default, or "--with-openblas").
         EOS
       end

--- a/suite-sparse421.rb
+++ b/suite-sparse421.rb
@@ -1,10 +1,12 @@
-class SuiteSparse < Formula
+class SuiteSparse421 < Formula
   desc "Suite of Sparse Matrix Software"
   homepage "http://faculty.cse.tamu.edu/davis/suitesparse.html"
-  url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz"
-  sha256 "f2ae47e96f3f37b313c3dfafca59f13e6dbc1e9e54b35af591551919810fb6fd"
+  url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.2.1.tar.gz"
+  mirror "http://pkgs.fedoraproject.org/repo/pkgs/suitesparse/SuiteSparse-4.2.1.tar.gz/4628df9eeae10ae5f0c486f1ac982fce/SuiteSparse-4.2.1.tar.gz"
+  sha256 "e8023850bc30742e20a3623fabda02421cb5774b980e3e7c9c6d9e7e864946bd"
 
   bottle do
+    root_url "https://homebrew.bintray.com/bottles-science"
     cellar :any
     revision 3
     sha256 "a8a12ded1414f3221509b8f69d5c31ef2c2b119dc0d7b1f4ea4b2280468ff211" => :yosemite
@@ -21,6 +23,8 @@ class SuiteSparse < Formula
 
   depends_on :fortran if build.with? "matlab"
 
+  keg_only "Conflicts with suite-sparse"
+
   def install
     # SuiteSparse doesn't like to build in parallel
     ENV.deparallelize
@@ -31,13 +35,7 @@ class SuiteSparse < Formula
     mv "SuiteSparse_config/SuiteSparse_config_Mac.mk",
        "SuiteSparse_config/SuiteSparse_config.mk"
 
-    cflags = (ENV.compiler == :clang) ? "" : "-fopenmp"
-
-    make_args = ["CFLAGS=#{cflags}",
-                 "INSTALL_LIB=#{lib}",
-                 "INSTALL_INCLUDE=#{include}",
-                 "RANLIB=echo",
-                ]
+    make_args = ["INSTALL_LIB=#{lib}", "INSTALL_INCLUDE=#{include}"]
     if build.with? "openblas"
       make_args << "BLAS=-L#{Formula["openblas"].opt_lib} -lopenblas"
     elsif OS.mac?
@@ -64,7 +62,6 @@ class SuiteSparse < Formula
       (doc/pkg).install Dir["#{pkg}/Doc/*"]
     end
 
-
     if build.with? "matlab"
       matlab = ARGV.value("with-matlab-path") || "matlab"
       system matlab,
@@ -90,10 +87,6 @@ class SuiteSparse < Formula
         Matlab interfaces and tools have been installed to
 
           #{share}/suite-sparse/matlab
-
-        It is possible that the SPQR interface fail to compile
-        if you use the defaults mexopts.sh or if your mexopts.sh
-        does not use gcc-4.9.
       EOS
     end
     s


### PR DESCRIPTION
If compiling the MEX interfaces, your `mexopts.sh` should use gcc-4.9 and gfortran-4.9 to avoid a compilation error of SPQR with clang.