### PR TITLE
bedtools: revert to 2.22.0

### DIFF
--- a/bedtools.rb
+++ b/bedtools.rb
@@ -4,16 +4,16 @@ class Bedtools < Formula
   homepage "https://github.com/arq5x/bedtools2"
   #doi "10.1093/bioinformatics/btq033"
   #tag "bioinformatics"
-  url "https://github.com/arq5x/bedtools2/releases/download/v2.22.1/bedtools-2.22.1.tar.gz"
-  sha1 "910d18a73b17f5c89abffc71228c2aeb4b608fac"
+  url "https://github.com/arq5x/bedtools2/releases/download/v2.22.0/bedtools-2.22.0.tar.gz"
+  sha1 "96f9f7031806de5d4ec694aeb9db31c3f8188f9b"
   head "https://github.com/arq5x/bedtools2.git"
 
   bottle do
     root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"
     cellar :any
-    sha1 "f7b153b5fc129babe4eb41a6a9986dd8491e4460" => :yosemite
-    sha1 "e451a3b3335dfa4d76eb0ddc7f6b19cea38db2a2" => :mavericks
-    sha1 "b7fc677ade53fc20c51c804e418313cb28ffa0ac" => :mountain_lion
+    sha1 "8c42e2006d59cbe8510acb245f2045602c7145b7" => :yosemite
+    sha1 "552196fd1fe129e24814ae0c6ddaa58baf6f7535" => :mavericks
+    sha1 "e94f17b8d473ebb26fb0acd7936bf268327f78b5" => :mountain_lion
   end
 
   def install


### PR DESCRIPTION
There is an issue with the new naming checks in bedtools 2.22.1 that
breaks it when running intersections on GRCh37 files
(arq5x/bedtools2#166) and we're running into issues after pulling in
the new version (https://github.com/chapmanb/bcbio-nextgen/issues/716#issuecomment-68903703).
This patch reverts to the previous 2.22.0 until there is a new
release/workaround.