### PR TITLE
snpEff: upgrade to 4.1

### DIFF
--- a/snpeff.rb
+++ b/snpeff.rb
@@ -2,17 +2,9 @@ require 'formula'
 
 class Snpeff < Formula
   homepage 'http://snpeff.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/snpeff/snpEff_v4_0_core.zip'
-  version '4.0e'
-  sha1 '969fa41cd774a33629f63938f665ba1f83f9adcc'
-
-  bottle do
-    root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"
-    cellar :any
-    sha1 "d663e17fc44066a66ae8f05a99d2b7e4fd1fdda8" => :yosemite
-    sha1 "fdbf0db244297f35281850bb2381d7abbba0392e" => :mavericks
-    sha1 "25acc2120b891e10c79530662578e24dc6ff20b8" => :mountain_lion
-  end
+  url 'https://downloads.sourceforge.net/project/snpeff/snpEff_v4_1_core.zip'
+  version '4.1'
+  sha1 "83e1d2e32bfc8b9104f1856e70f8b1112fa290ab"
 
   def install
     inreplace "scripts/snpEff" do |s|


### PR DESCRIPTION
This follows @heuermh upgrade to 4.0 to the latest 4.1 release from last
week. The 3.6 to 4.0 transition is pretty tricky as their are database
incompatibilities and the snpEff databases are not versioned as of 4.0.
4.1 introduces versioning so is an easier upgrade path from 3.6 and
should make things generally easier going forward.