### PR TITLE
nauty 2.5r9

### DIFF
--- a/nauty.rb
+++ b/nauty.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Nauty < Formula
   homepage "http://cs.anu.edu.au/~bdm/nauty/"
-  url "http://cs.anu.edu.au/~bdm/nauty/nauty24r2.tar.gz"
-  version "24r2"
-  sha1 "3f012beb399a9340f77d0104bf1c9bf1100e8286"
+  url "http://cs.anu.edu.au/~bdm/nauty/nauty25r9.tar.gz"
+  version "25r9"
+  sha1 "a533cfd764bf56b35e117c46cb85b0142833e8b2"
 
   deprecated_option "run-tests" => "with-checks"
   option "without-checks", "Runs the included test programs"
@@ -17,14 +17,15 @@ class Nauty < Formula
 
     bin.install %w{ NRswitchg addedgeg amtog biplabg catg complg copyg countg
       deledgeg directg dreadnaut dretog genbg geng genrang gentourng labelg
-      listg multig newedgeg pickg planarg shortg showg }
+      linegraphg listg multig newedgeg pickg planarg ranlabg shortg showg subdivideg
+      watercluster2 }
 
-    prefix.install "nug.pdf"
+    prefix.install "nug25.pdf"
   end
 
   def caveats; <<-EOS.undent
     User guide was saved locally to:
-      #{prefix}/nug.pdf
+      #{prefix}/nug25.pdf
     EOS
   end
 end


### PR DESCRIPTION
- Update nauty formula from 24r2 to 25r9
- Add the new 4 executable mentionned in changelog
(http://cs.anu.edu.au/~bdm/nauty/changes24-25.txt):
ranlabg, linegraphg, subdivideg, watercluster2
- Copy the pdf manual (which name changed)