### PR TITLE
libccd 2.0 and update test

### DIFF
--- a/libccd.rb
+++ b/libccd.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Libccd < Formula
   homepage 'http://libccd.danfis.cz'
-  url 'http://libccd.danfis.cz/files/libccd-1.4.tar.gz'
-  sha1 'abf924ad6e3f427d58734f67348de23970704cbd'
+  url 'http://libccd.danfis.cz/files/libccd-2.0.tar.gz'
+  sha1 'f6ab9053c7f3b18a781c8be973c1844c4421936a'
   head 'https://github.com/danfis/libccd.git'
 
   depends_on 'cmake' => :build
@@ -15,14 +15,15 @@ class Libccd < Formula
 
   test do
     (testpath/'test.c').write <<-EOS.undent
-      #include <ccd/polytope.h>
+      #include <ccd/vec3.h>
       int main() {
-        ccd_pt_t polytope;
-        ccdPtInit(&polytope);
+        ccdVec3PointSegmentDist2(
+          ccd_vec3_origin, ccd_vec3_origin,
+          ccd_vec3_origin, NULL);
         return 0;
       }
     EOS
-    system ENV.cc, "-o", "test", "test.c", "-lccd"
+    system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lccd"
     system "./test"
   end
 end


### PR DESCRIPTION
Update the libccd formula to 2.0 (the latest version).
This requires the test to be fixed since the polytope.h
header file is no longer installed.