### PR TITLE
bump gal-sim to new release 1.2.0

### DIFF
--- a/gal-sim.rb
+++ b/gal-sim.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class GalSim < Formula
   homepage "https://github.com/GalSim-developers/GalSim"
-  url "https://github.com/GalSim-developers/GalSim/archive/v1.1.0.tar.gz"
-  sha1 'a1446f73053b4dc91f62d236193ba6ccb1fb9ae5'
+  url "https://github.com/GalSim-developers/GalSim/archive/v1.2.0.tar.gz"
+  sha1 "0437b4a55c6a73ad547e5e0ff3643bc0d26134c6"
   head "https://github.com/GalSim-developers/GalSim.git"
   revision 1
 

--- a/gal-sim.rb
+++ b/gal-sim.rb
@@ -5,7 +5,6 @@ class GalSim < Formula
   url "https://github.com/GalSim-developers/GalSim/archive/v1.2.0.tar.gz"
   sha1 "0437b4a55c6a73ad547e5e0ff3643bc0d26134c6"
   head "https://github.com/GalSim-developers/GalSim.git"
-  revision 1
 
   depends_on "scons" => :build
   depends_on "fftw"


### PR DESCRIPTION
The galaxy simulation toolkit gal-sim just released 1.2.0, important because it is the version referred-to in the major paper on the Great3 simulation challenge.
No drama witnessed in the build.

