### PR TITLE
BEDOPS 2.4.6

### DIFF
--- a/bedops.rb
+++ b/bedops.rb
@@ -3,18 +3,10 @@ class Bedops < Formula
   #doi "10.1093/bioinformatics/bts277"
   #tag "bioinformatics"
 
-  url "https://github.com/bedops/bedops/archive/v2.4.3.tar.gz"
-  sha1 "d9304c63f53cb948e59fe04b0ea96c3ea4da1da3"
+  url "https://github.com/bedops/bedops/archive/v2.4.6.tar.gz"
+  sha1 "c7bb6e7308f43a05d6391da08a5548c9e0c1662e"
 
   head 'https://github.com/bedops/bedops.git'
-
-  bottle do
-    root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"
-    cellar :any
-    sha1 "a11fa843cf57a66cc8df65c9258589678a162790" => :yosemite
-    sha1 "aa9862870a8b866d3fa4cea6ec50d16107ecbe83" => :mavericks
-    sha1 "edd6cbf28e1c1f9f4db6fcec8ce373bfc1e12554" => :mountain_lion
-  end
 
   env :std
 


### PR DESCRIPTION
* Document style changes that improve mobile device support
* Support for RepeatMasker annotation output and GVF formats in `convert2bed`
* Bug fix in `convert2bed` for GFF and GTF formats
* General document typo fixes
* 19M reduction in repository size