### PR TITLE
Cytoscape 3.2.1

### DIFF
--- a/cytoscape.rb
+++ b/cytoscape.rb
@@ -2,18 +2,10 @@ class Cytoscape < Formula
   homepage "http://www.cytoscape.org/"
   # tag "bioinformatics"
   # doi "10.1038/nmeth.2212"
-  url "http://chianti.ucsd.edu/cytoscape-3.2.0/cytoscape-3.2.0.tar.gz"
-  sha1 "a0bc0832ef986d98bfbe5d9f377f87df0efb1d6d"
+  url "http://chianti.ucsd.edu/cytoscape-3.2.1/cytoscape-3.2.1.tar.gz"
+  sha1 "d49b2da44d6f6330b77450d2899bb5c29b874a58"
 
-  bottle do
-    root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"
-    cellar :any
-    sha1 "c0e15358a96ac2b9504b676c6353fd0e583a5877" => :yosemite
-    sha1 "62659dcc978f91da8ea71b2c65eea349a23103a9" => :mavericks
-    sha1 "b30e494d4dd8b66c77cddf7810c447910db884a0" => :mountain_lion
-  end
-
-  depends_on :java => "1.7"
+  depends_on :java => "1.8"
 
   def install
     inreplace "cytoscape.sh", "$script_path", prefix


### PR DESCRIPTION
Version bump.
Cytoscape v3.2.1 contains full support for Java 8 and 43 bug and feature fixes, including:
- Command scripts can be executed from the command line using the –s option
- Various layouts now honor node selection
- Improvements for accessing Cytoscape data model and functions via cyREST
- Lots of cosmetic improvements, and minor fixes for app writers