### PR TITLE
gdcm 2.4.4: added options to build Python bindings

### DIFF
--- a/gdcm.rb
+++ b/gdcm.rb
@@ -6,12 +6,19 @@ class Gdcm < Formula
   sha1 "4b77a857cf8432da72140a5e7d20f78c091ee019"
 
   option "with-check", "Run the GDCM test suite"
+  depends_on :python => :optional
+  depends_on :python3 => :optional
 
   option :cxx11
   cxx11dep = (build.cxx11?) ? ['c++11'] : []
 
   depends_on "cmake" => :build
   depends_on "vtk" => [:optional] + cxx11dep
+  depends_on "swig" => :build if build.with? "python" or build.with? "python3"
+
+  if build.with? "python" and build.with? "python3"
+    raise "Recipe may only be installed for one python type."
+  end
 
   def install
     sourcedir = "#{pwd}/source_files"
@@ -25,6 +32,29 @@ class Gdcm < Formula
     end
     mkdir builddir do
       args = std_cmake_args
+
+      if build.with? "python" or build.with? "python3"
+        python_executable = `which python`.strip if build.with? "python"
+        python_executable = `which python3`.strip if build.with? "python3"
+
+        python_prefix = %x(#{python_executable} -c 'import sys;print(sys.prefix)').chomp
+        python_include = %x(#{python_executable} -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))').chomp
+        python_version = "python" + %x(#{python_executable} -c 'import sys;print(sys.version[:3])').chomp
+        py_site_packages = "#{lib}/#{python_version}/site-packages"
+
+        args << "-DPYTHON_EXECUTABLE='#{python_executable}'"
+        args << "-DPYTHON_INCLUDE_DIR='#{python_include}'"
+        if File.exist? "#{python_prefix}/Python"
+          args << "-DPYTHON_LIBRARY='#{python_prefix}/Python'"
+        elsif File.exist? "#{python_prefix}/lib/lib#{python_version}.a"
+          args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/lib#{python_version}.a'"
+        else
+          args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/lib#{python_version}.dylib'"
+        end
+        args << "-DGDCM_WRAP_PYTHON=ON"
+        args << "-DGDCM_INSTALL_PYTHONMODULE_DIR='#{py_site_packages}'"
+      end
+
       args << "-DGDCM_BUILD_APPLICATIONS=ON"
       args << "-DGDCM_BUILD_EXAMPLES=ON"
       args << "-DGDCM_BUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
Repost of #1252 with merge fixed.