### PR TITLE
BEDOPS 2.4.10

### DIFF
--- a/bedops.rb
+++ b/bedops.rb
@@ -3,8 +3,8 @@ class Bedops < Formula
   #doi "10.1093/bioinformatics/bts277"
   #tag "bioinformatics"
 
-  url "https://github.com/bedops/bedops/archive/v2.4.9.tar.gz"
-  sha1 "7d3bb19d15fc29fa77b82362074d896a5a5b021e"
+  url "https://github.com/bedops/bedops/archive/v2.4.10.tar.gz"
+  sha1 "bd20a992b59374ca0f4c3960f304a6291dbd8df6"
 
   head 'https://github.com/bedops/bedops.git'
 


### PR DESCRIPTION
``starch``

* Enforces ``sort-bed`` sort ordering on BED input and exits with ``EINVAL`` error if data are not sorted correctly.

``convert2bed``

* Added ``--zero-indexed`` option to ``wig2bed`` and ``wig2starch`` wrappers and ``convert2bed`` binary, which converts WIG data that are zero-indexed without any coordinate adjustments. This is useful for WIG data sourced from the UCSC Kent tool ``bigWigToWig``, where the bigWig data can potentially be sourced from 0-indexed BAM- or bedGraph-formatted data.

* If the WIG input contains any element with a start coordinate of 0, the default use of ``wig2bed``, ``wig2starch`` and ``convert2bed`` will exit early with an error condition, suggesting the use of ``--zero-indexed``.

* Updated copyright date range of wrapper scripts