### PR TITLE
Parmetis (update for Linuxbrew)

### DIFF
--- a/parmetis.rb
+++ b/parmetis.rb
@@ -22,7 +22,8 @@ class Parmetis < Formula
   patch :DATA
 
   def install
-    ENV["LDFLAGS"] = "-L#{Formula["metis"].lib} -lmetis"
+    ENV["LDFLAGS"] = "-L#{Formula["metis"].lib} -lmetis -lm"
+
     system "make", "config", "prefix=#{prefix}", "shared=1"
     system "make", "install"
     share.install "Graphs" # Sample data for test


### PR DESCRIPTION
Added extra LDFLAGS and CFLAGS.
-lm (libm) was needed to compile on Linuxbrew and -fPIC helps with
linking shared libraries on Linuxbrew.
Other CFLAGS are taken from the Petsc build script.