### PR TITLE
glpk: build with gmp

### DIFF
--- a/glpk.rb
+++ b/glpk.rb
@@ -12,9 +12,12 @@ class Glpk < Formula
     sha1 "0d02d5430580f440c1477996dffa596871931796" => :mountain_lion
   end
 
+  depends_on "gmp" => :recommended
+
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
+    args << "--with-gmp" if build.with? "gmp"
+    system "./configure", *args
     system "make"
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
From the GLPK v4.52 manual:
This feature allows the exact simplex solver to use the GNU MP bignum
library. If it is disabled, the exact simplex solver uses the GLPK
bignum module, which provides the same functionality as GNU MP, however,
it is much less efficient.