### PR TITLE
qualimap: last version with cleaner log and minor bug fixed

### DIFF
--- a/qualimap.rb
+++ b/qualimap.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Qualimap < Formula
   homepage 'http://qualimap.bioinfo.cipf.es/'
-  url 'https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-06-03-15.tar.gz'
-  sha1 'fc0a227d2739a1e92b95cfabee074dc54d4c7ce6'
-  version '06-03-15'
+  url 'https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-30-03-15.tar.gz'
+  sha1 'ce5c8262493bda49f3eafd2568b11dfc84af7f64'
+  version '30-03-15'
   bottle do
     root_url "https://homebrew.bintray.com/bottles-science"
     cellar :any
@@ -12,7 +12,6 @@ class Qualimap < Formula
     sha256 "1916bbaaf3d8e81cb365fa38d55ca45d80e500d917f73b5da8b207286bdf7900" => :mavericks
     sha256 "203dea1e6ffaa55e9b09215e689dfd41b6118149397773cd76bdfcf7651d7ba9" => :mountain_lion
   end
-
   depends_on 'r' => :optional
 
   def install


### PR DESCRIPTION
There is a better version that avoid to full the log file with the same message. Would be good to have that to update bcbio-nextgen as well. 

The only thing is that bottles need to be updated, but I guess only some people can do it?

thanks