### PR TITLE
Etsf io: change Fortran module dir

### DIFF
--- a/etsf_io.rb
+++ b/etsf_io.rb
@@ -2,6 +2,7 @@ class EtsfIo < Formula
   homepage "http://www.etsf.eu/resources/software/libraries_and_tools"
   url "http://www.etsf.eu/system/files/etsf_io-1.0.4.tar.gz"
   sha256 "3140c2cde17f578a0e6b63acb27a5f6e9352257a1371a17b9c15c3d0ef078fa4"
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles-science"
@@ -16,7 +17,7 @@ class EtsfIo < Formula
   depends_on "netcdf" => ["with-fortran"]
 
   def install
-    system "./configure", "--prefix=#{prefix}",
+    system "./configure", "--prefix=#{prefix}", "--with-moduledir=#{include}",
            "--with-netcdf-incs=-I#{Formula["netcdf"].opt_include}",
            "--with-netcdf-libs=-L#{Formula["netcdf"].opt_lib} -lnetcdff -lnetcdf"
 


### PR DESCRIPTION
Fortran modules were installed in etsf_io/include/gcc; this was not portable and not easy to use in other formulae. Changed this to etsf_io/include.