### PR TITLE
BEDOPS 2.4.14

### DIFF
--- a/bedops.rb
+++ b/bedops.rb
@@ -3,8 +3,8 @@ class Bedops < Formula
   #doi "10.1093/bioinformatics/bts277"
   #tag "bioinformatics"
 
-  url "https://github.com/bedops/bedops/archive/v2.4.12.tar.gz"
-  sha1 "51c6621b15fe159d73ea71019d982b6402f68e80"
+  url "https://github.com/bedops/bedops/archive/v2.4.14.tar.gz"
+  sha1 "7e7f721b033f9d4b706c036d439af3f3bb0c5efe"
 
   head 'https://github.com/bedops/bedops.git'
 


### PR DESCRIPTION
**bedops**

* Resolved issue in using `--ec` with `bedops` when reading from `stdin` (thanks to Brad Gulko for the bug report).

**convert2bed**

* Fixed missing `samtools` variable references in cluster conversion scripts (thanks to Brad Gulko for the bug report).

**General suite-wide improvements**

* Fixed exception error message for `stdin` check (thanks to Brad Gulko for the bug report).

* Addressed inconsistency with constants defined for the suite at the extreme end of the limits we allow for coordinate values (thanks again to Brad Gulko for the report).