### PR TITLE
field3d 1.6.1

### DIFF
--- a/field3d.rb
+++ b/field3d.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Field3d < Formula
-  homepage 'https://sites.google.com/site/field3d/'
-  url 'https://github.com/imageworks/Field3D/archive/v1.4.3.tar.gz'
-  sha1 '2a6d2bc535cd6c89cbb9dd2fe24734bd83dd9426'
-  revision 1
+  homepage "https://sites.google.com/site/field3d/"
+  url "https://github.com/imageworks/Field3D/archive/v1.6.1.tar.gz"
+  sha256 "05dcf96db1779c2db8fc9de518bbc8482f43e8cd8cb995ebb06fb22d83879a5a"
+
+  head "https://github.com/imageworks/Field3D.git"
 
   bottle do
     root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"
@@ -14,14 +13,28 @@ class Field3d < Formula
     sha1 "9e7854c38d8af4a2f07f21b931d2751a533813e9" => :mountain_lion
   end
 
-  depends_on 'cmake' => :build
-  depends_on 'boost'
-  depends_on 'ilmbase'
-  depends_on 'hdf5'
+  depends_on "scons" => :build
+  depends_on "boost"
+  depends_on "ilmbase"
+  depends_on "hdf5"
 
   def install
-    args = std_cmake_args + %w[-DDOXYGEN_EXECUTABLE=NOTFOUND]
-    system "cmake",  *args
-    system "make install"
+    scons
+
+    include.install Dir["install/**/**/release/include/*"]
+    lib.install Dir["install/**/**/release/lib/*"]
+    man1.install "man/f3dinfo.1"
+    (share/"field3d").install "contrib", "test", "apps/sample_code"
+  end
+
+  test do
+    system ENV.cxx, "-I#{include}", "-L#{lib}", "-lfield3d",
+           "-I#{Formula["boost"].opt_include}",
+           "-L#{Formula["boost"].opt_lib}", "-lboost_system",
+           "-I#{Formula["hdf5"].opt_include}",
+           "-L#{Formula["hdf5"].opt_lib}", "-lhdf5",
+           share/"field3d/sample_code/create_and_write/main.cpp",
+           "-o", "test"
+    system "./test"
   end
 end

--- a/openimageio.rb
+++ b/openimageio.rb
@@ -4,6 +4,7 @@ class Openimageio < Formula
   homepage "http://openimageio.org"
   url "https://github.com/OpenImageIO/oiio/archive/Release-1.5.13.tar.gz"
   sha256 "ff9fd20eb2ad3a4d05e9e2849f18a62d4fe7a9330de21f177db597562d947429"
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles-science"


### PR DESCRIPTION
If someone wants to build it on a linux machine I can change these lines to be cross-platform:

```
include.install "install/darwin/#{arch}/release/include/Field3D"
lib.install Dir["install/darwin/#{arch}/release/lib/*"]
```