### PR TITLE
SuperluDist (fix)

### DIFF
--- a/superlu_dist.rb
+++ b/superlu_dist.rb
@@ -1,7 +1,7 @@
 class SuperluDist < Formula
   homepage "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/"
   url "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_3.3.tar.gz"
-  sha1 "1f44b6e8382b402a61ef107d962f8602e90498a4"
+  sha256 "d2fd8dc847ae63ed7980cff2ad4db8d117640ecdf0234c9711e0f6ee1398cac2"
   revision 1
 
   bottle do
@@ -19,6 +19,8 @@ class SuperluDist < Formula
   depends_on "openblas" => :optional
 
   def install
+    # prevent linking errors on linuxbrew:
+    ENV.deparallelize
     rm "#{buildpath}/make.inc"
     blaslib = ((build.with? "openblas") ? "-L#{Formula["openblas"].opt_lib} -lopenblas" : "-framework Accelerate")
     (buildpath / "make.inc").write <<-EOS.undent


### PR DESCRIPTION
Fix linking errors on Linuxbrew by ENV.deparallelize.

see https://github.com/Homebrew/linuxbrew/issues/372