### PR TITLE
genometools: Add symlink for gtdata dir

### DIFF
--- a/genometools.rb
+++ b/genometools.rb
@@ -38,7 +38,7 @@ class Genometools < Formula
     system "make", "test", *args if build.with? "check"
     system "make", "install", *args
 
-    (share/"genometools").install bin/"gtdata"
+    prefix.install bin/"gtdata"
   end
 
   test do


### PR DESCRIPTION
Add symlink for `/gtdata` dir for homebrew installs not in `/usr/local`.

This is the other half of genometools/genometools#569