### PR TITLE
Updated Alembic formula

### DIFF
--- a/alembic.rb
+++ b/alembic.rb
@@ -1,18 +1,17 @@
-require "formula"
 
 class Alembic < Formula
   homepage "http://alembic.io"
-  head "https://code.google.com/p/alembic/", :using => :hg
-  url "https://code.google.com/p/alembic/", :using => :hg,
-    :tag => "1_05_04"
-  version "1.5.4"
+  url "https://github.com/alembic/alembic/archive/1.5.8.zip"
+  sha256 "1f347a0e310d096370fe2afd3a83674e9a00776f1ab74ec601fddbf8657ed568"
+  version "1.5.8"
+  head "https://github.com/alembic/alembic.git", :using => :git
 
   needs :cxx11
-
-  depends_on "cmake" => :build
-  depends_on "boost"
-  depends_on "hdf5"
+  depends_on "cmake"    => :build
+  depends_on "hdf5"     => :recommended
+  depends_on "openexr"  => :recommended
   depends_on "ilmbase"
+  depends_on "boost"
 
   def install
     cmake_args = std_cmake_args + %W[
@@ -21,12 +20,12 @@ class Alembic < Formula
       -DUSE_ARNOLD=OFF
       -DUSE_MAYA=OFF
       -DUSE_PYALEMBIC=OFF
-      -DCMAKE_CXX_FLAGS='-std=c++11'
+      -DCMAKE_CXX_FLAGS='-std=c++11\ -stdlib=libc++'
     ]
     system "cmake", ".", *cmake_args
     system "make", "install"
 
-    #move everything upwards
+    # move everything upwards
     lib.install_symlink Dir[prefix/"alembic-#{version}/lib/static/*"]
     include.install_symlink Dir[prefix/"alembic-#{version}/include/*"]
     bin.install_symlink Dir[prefix/"alembic-#{version}/bin/*"]


### PR DESCRIPTION
* removed `require "formula"` line
* Added `:recommended` flags to hdf5 and openexr requirements,
  [per the upstream README](https://github.com/alembic/alembic/blob/e6c90d4faa32c4550adeaaf3f556dad4b73a92bb/README.txt#L13-L26)
* Updated `url` and `head` to point at current project repository
  (specifically, `url` points to a zipped source release instead of an SCM tag)
* Updated stable version to 1.5.8 and added sha256 hash
* Links to libc++
* [amend] Trimmed trailing whitespace