### PR TITLE
r: build language reference

### DIFF
--- a/r.rb
+++ b/r.rb
@@ -29,6 +29,7 @@ class R < Formula
   option "with-librmath-only", "Only build standalone libRmath library"
 
   depends_on "pkg-config" => :build
+  depends_on "texinfo" => :build
   depends_on :fortran
   depends_on "readline"
   depends_on "gettext"


### PR DESCRIPTION
R uses texi2any to build manuals to html, which isn't shipped with OS X.

Closes #2378.