### PR TITLE
clarify rJava caveat in r.rb

### DIFF
--- a/r.rb
+++ b/r.rb
@@ -165,7 +165,8 @@ class R < Formula
         R CMD javareconf JAVA_CPPFLAGS=-I/System/Library/Frameworks/JavaVM.framework/Headers
       If you've installed a version of Java other than the default, you might need to instead use:
         R CMD javareconf JAVA_CPPFLAGS="-I/System/Library/Frameworks/JavaVM.framework/Headers -I/Library/Java/JavaVirtualMachines/jdk<version>.jdk/"
-        (where <version> can be found by running `java -version` or `locate jni.h`)
+      (where <version> can be found by running `java -version`, `/usr/libexec/java_home`, or `locate jni.h`), or:
+        R CMD javareconf JAVA_CPPFLAGS="-I/System/Library/Frameworks/JavaVM.framework/Headers -I$(/usr/libexec/java_home | grep -o '.*jdk')"
       EOS
     end
   end


### PR DESCRIPTION
Add a programmatic way to construct the `R CMD javareconf` command.