### PR TITLE
diamond: No longer needs openmp.

### DIFF
--- a/diamond.rb
+++ b/diamond.rb
@@ -1,13 +1,11 @@
 class Diamond < Formula
+  desc "Accelerated BLAST compatible local sequence aligner"
   homepage "http://ab.inf.uni-tuebingen.de/software/diamond/"
   # doi "10.1038/nmeth.3176"
   # tag "bioinformatics"
 
   url "https://github.com/bbuchfink/diamond/archive/v0.7.9.tar.gz"
   sha256 "25dc43e41768f7a41c98b8b1dcf5aa2c51c0eaf62e71bff22ad01c97b663d341"
-
-  # Fix fatal error: 'omp.h' file not found
-  needs :openmp
 
   depends_on "boost"
 


### PR DESCRIPTION
As said in the ChangeLog, it no longer needs openmp.