### PR TITLE
wcslib: bump version to 5.7

### DIFF
--- a/wcslib.rb
+++ b/wcslib.rb
@@ -1,7 +1,7 @@
 class Wcslib < Formula
   homepage "http://www.atnf.csiro.au/people/mcalabre/WCS/"
-  url "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-4.23.tar.bz2"
-  sha1 "6b335277b4915c76d74b222f0e63a33e49f7d857"
+  url "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.7.tar.bz2"
+  sha1 "93555d3bab4a97944a6c371713d933725fcebc26"
 
   bottle do
     root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"

--- a/wcslib.rb
+++ b/wcslib.rb
@@ -1,7 +1,7 @@
 class Wcslib < Formula
   homepage "http://www.atnf.csiro.au/people/mcalabre/WCS/"
   url "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.7.tar.bz2"
-  sha1 "93555d3bab4a97944a6c371713d933725fcebc26"
+  sha256 "a0822088ddd128618b5fbbbc1787f5a80568da4f4f53ce76545c9cf1f4140632"
 
   bottle do
     root_url "https://downloads.sf.net/project/machomebrew/Bottles/science"


### PR DESCRIPTION
The wcslib author has a habit of removing old wcslib releases, so the current formula no longer builds (tarball is not available at that URL any more).  This PR bumps to the more recent release.

Major version 5.x adds better support for polynomial distortions, including the two major forms found in the wild, TPV and SIP.  I don't believe the API has changed.

