### PR TITLE
Fixes PCL --HEAD

### DIFF
--- a/pcl.rb
+++ b/pcl.rb
@@ -98,6 +98,7 @@ class Pcl < Formula
       -DBUILD_global_tests:BOOL=OFF
       -DWITH_TUTORIALS:BOOL=OFF
       -DWITH_DOCS:BOOL=OFF
+      -DPCL_QT_VERSION=4
     ]
 
     if build.head? && (build.with? "cuda")


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-science/issues/2346. PCL now expects QT5 by default, so we need to tell him to use QT4. Need to investigate QT5 support in HEAD.