### PR TITLE
gnudatalanguage: support for plplot 5.11.0

### DIFF
--- a/gnudatalanguage.rb
+++ b/gnudatalanguage.rb
@@ -1,7 +1,9 @@
 class Gnudatalanguage < Formula
+  desc "A free and open-source IDL/PV-WAVE compiler"
   homepage "http://gnudatalanguage.sourceforge.net"
   url "https://downloads.sourceforge.net/project/gnudatalanguage/gdl/0.9.5/gdl-0.9.5.tar.gz"
   sha256 "cc9635e836b5ea456cad93f8a07d589aed8649668fbd14c4aad22091991137e2"
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles-science"
@@ -12,7 +14,7 @@ class Gnudatalanguage < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "plplot"
+  depends_on "plplot" => "with-x11"
   depends_on "gsl"
   depends_on "readline"
   depends_on "graphicsmagick"
@@ -32,6 +34,12 @@ class Gnudatalanguage < Formula
   patch :p0 do
     url "https://gist.githubusercontent.com/iml/ee107290ee5cd2850190/raw/83c046bce9facda8c560a8d38ea02913892c4b88/gnudatalanguage.diff"
     sha256 "b2e9b2c1ed51676e048441b7bfc160488fdf5898b1d1c9396bc58eb85996981e"
+  end
+
+  # restores compatibility with latest plplot. Patch found upstream at http://sourceforge.net/p/gnudatalanguage/bugs/643/
+  patch do
+    url "https://gist.github.com/tschoonj/e01c72165fd2cb9a68c9/raw/5143168a04de0d4f8fc6c3621733ce68fe7c6268/gdl-plplot.patch"
+    sha256 "937e82f6052aa72576df49046aa57d03593c7ba21d074f2455cd614318b881dd"
   end
 
   def install


### PR DESCRIPTION
The last release of plplot (Homebrew/homebrew#41187) introduces several backwards
incompatibilities that need patching in gnudatalanguage.

This commit should take care of that...