### PR TITLE
gff3toembl: Converter for going from GFF3 to an EMBL submission format (new formula)

### DIFF
--- a/gff3toembl.rb
+++ b/gff3toembl.rb
@@ -1,0 +1,24 @@
+class Gff3toembl < Formula
+  desc "Convert GFF3 files to a format suitable for submission to EMBL"
+  homepage "https://github.com/sanger-pathogens/gff3toembl"
+  url "https://github.com/sanger-pathogens/gff3toembl/archive/v1.0.0.tar.gz"
+  sha256 "a224e5406098714a12d257e307239120150e80b8b75fcf2f77149ed034757f38"
+  head "https://github.com/sanger-pathogens/gff3toembl.git"
+  # tag "bioinformatics"
+
+  depends_on :python
+  depends_on "genometools"
+
+  def install
+    version = Language::Python.major_minor_version "python"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
+
+    system "python", *Language::Python.setup_install_args(libexec)
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    assert_match "Converts prokaryote GFF3 annotations to EMBL for ENA submission", shell_output("gff3_to_embl -h 2>&1", 0)
+  end
+end

--- a/gff3toembl.rb
+++ b/gff3toembl.rb
@@ -1,10 +1,11 @@
 class Gff3toembl < Formula
   desc "Convert GFF3 files to a format suitable for submission to EMBL"
   homepage "https://github.com/sanger-pathogens/gff3toembl"
-  url "https://github.com/sanger-pathogens/gff3toembl/archive/v1.0.0.tar.gz"
-  sha256 "a224e5406098714a12d257e307239120150e80b8b75fcf2f77149ed034757f38"
-  head "https://github.com/sanger-pathogens/gff3toembl.git"
   # tag "bioinformatics"
+
+  url "https://github.com/sanger-pathogens/gff3toembl/archive/v1.1.0.tar.gz"
+  sha256 "f5ec9e08660519be6be22b487c9acceabb629bb19c8e45bc09df74d15b2bdae7"
+  head "https://github.com/sanger-pathogens/gff3toembl.git"
 
   depends_on :python
   depends_on "genometools"


### PR DESCRIPTION
Takes a GFF3 file (such as those created by prokka @torstenseemann ) and converts it to a format valid for submission to EMBL.  This isnt a generic converter. Data thats not valid for EMBL gets stripped out or modified to make it valid.
This depends on the GenomeTools python library, which is exposed with this pull request:
https://github.com/Homebrew/homebrew-science/pull/2524
