### PR TITLE
arpack 3.2.0 (update)

### DIFF
--- a/arpack.rb
+++ b/arpack.rb
@@ -1,15 +1,18 @@
 class Arpack < Formula
-  homepage "http://forge.scilab.org/index.php/p/arpack-ng"
-  url "http://forge.scilab.org/index.php/p/arpack-ng/downloads/get/arpack-ng_3.1.4.tar.gz"
-  sha1 "1fb817346619b04d8fcdc958060cc0eab2c73c6f"
-  head "git://git.forge.scilab.org/arpack-ng.git"
-  revision 2
+  desc "ARPACK is a collection of Fortran77 subroutines designed to solve large scale eigenvalue problems."
+  homepage "https://github.com/opencollab/arpack-ng"
+  url "https://github.com/opencollab/arpack-ng/archive/3.2.0.tar.gz"
+  sha256 "ce6de85d8de6ae3a741fb9d6169c194ff1b2ffdab289f7af8e41d71bb7818cbb"
+  head "https://github.com/opencollab/arpack-ng.git"
 
   bottle do
     sha256 "6279a2b0072b0e362d50d218fde6b0ec6ce0dd841e7c143f0045ea0b60601f34" => :yosemite
     sha256 "13e906401589f1964d9847e6e291b03f55bf8de7b25968d6ca31124482a8ff6e" => :mavericks
     sha256 "a17839b8ec3e0599361674bc2211cff6705e04661cab093f80ea4edea2b757b0" => :mountain_lion
   end
+
+  # TODO: enable with 3.3.0
+  # option "without-check", "skip tests (not recommended)"
 
   depends_on :fortran
   depends_on :mpi => [:optional, :f77]
@@ -30,8 +33,13 @@ class Arpack < Formula
       args << "--with-blas=-lblas -llapack"
     end
 
+    # HEAD version does not contain generated configure scirpt
+    # must bootstrap first:
+    system "./bootstrap" if build.head?
+
     system "./configure", *args
     system "make"
+    system "make", "check" if build.with? "check"
     system "make", "install"
     lib.install_symlink Dir["#{libexec}/lib/*"].select { |f| File.file?(f) }
     (lib / "pkgconfig").install_symlink Dir["#{libexec}/lib/pkgconfig/*"]
@@ -39,9 +47,11 @@ class Arpack < Formula
   end
 
   test do
-    cd libexec/"share" do
-      ["dnsimp", "bug_1323"].each do |slv|
-        system "#{libexec}/bin/#{slv}"  # Reads testA.mtx
+    if build.with? "mpi"
+      cd libexec/"bin" do
+        ["pcndrv1", "pdndrv1", "pdndrv3", "pdsdrv1", "psndrv3", "pssdrv1", "pzndrv1"].each do |slv|
+          system "mpirun -np 4 #{slv}" if build.with? "mpi"
+        end
       end
     end
   end


### PR DESCRIPTION
so far some tests fail: https://github.com/opencollab/arpack-ng/issues/17

note that there are a lot of issues with failing tests, not only on mac, but also on linux. The good sign is that all tests including installed MPI binaries run without segmentation fault ;-)

p.s. tests fail both for `openblas` and `veclibfort`.

