### PR TITLE
vislcg3: update download URL and hash

### DIFF
--- a/vislcg3.rb
+++ b/vislcg3.rb
@@ -3,8 +3,8 @@ require "open3"
 
 class Vislcg3 < Formula
   homepage "http://beta.visl.sdu.dk/cg3.html"
-  url "http://beta.visl.sdu.dk/download/vislcg3/vislcg3-0.9.8.10063.tar.bz2"
-  sha1 "98943be3d85824be9c256b501f8c58cd937c51ee"
+  url "http://beta.visl.sdu.dk/download/vislcg3/cg3-0.9.9~r10800.tar.bz2"
+  sha256 "c85446c671fdb55dc01bf6092dd32ccb05ad4e057563d5c4293ee2409df610ba"
   head "http://beta.visl.sdu.dk/svn/visl/tools/vislcg3/trunk", :using => :svn
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Old download URL is now 404. You can verify this at http://beta.visl.sdu.dk/download/vislcg3