### PR TITLE
bump gal-sim to latest release, v1.3.0

### DIFF
--- a/gal-sim.rb
+++ b/gal-sim.rb
@@ -1,6 +1,7 @@
 require "formula"
 
 class GalSim < Formula
+  desc "A modular galaxy image simulation toolkit"
   homepage "https://github.com/GalSim-developers/GalSim"
   url "https://github.com/GalSim-developers/GalSim/archive/v1.3.0.tar.gz"
   sha256 "4afd3284adfd12845b045ea3c8e293b63057c7da57872bc9eecd005cf0a763c0"

--- a/gal-sim.rb
+++ b/gal-sim.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class GalSim < Formula
   homepage "https://github.com/GalSim-developers/GalSim"
-  url "https://github.com/GalSim-developers/GalSim/archive/v1.2.0.tar.gz"
-  sha1 "0437b4a55c6a73ad547e5e0ff3643bc0d26134c6"
+  url "https://github.com/GalSim-developers/GalSim/archive/v1.3.0.tar.gz"
+  sha256 "4afd3284adfd12845b045ea3c8e293b63057c7da57872bc9eecd005cf0a763c0"
   head "https://github.com/GalSim-developers/GalSim.git"
 
   depends_on "scons" => :build


### PR DESCRIPTION
Routine update.

Release notes for v1.3.0 of GalSim are here:
https://github.com/GalSim-developers/GalSim/blob/releases/1.3/CHANGELOG.md
