### PR TITLE
GalSim: fix build when homebrew is not in /usr/local or other default search path

### DIFF
--- a/gal-sim.rb
+++ b/gal-sim.rb
@@ -31,7 +31,7 @@ class GalSim < Formula
       args << "WITH_OPENMP=true"
     end
     scons *args
-    scons "install", "PREFIX=#{prefix}", "PYPREFIX=#{lib}/python#{pyver}"
+    scons "install", "PREFIX=#{prefix}", "PYPREFIX=#{lib}/python#{pyver}", "EXTRA_INCLUDE_PATH=#{HOMEBREW_PREFIX}/include", "EXTRA_LIB_PATH=#{HOMEBREW_PREFIX}/lib", "EXTRA_PATH=#{HOMEBREW_PREFIX}/bin"
   end
 
   def caveats; <<-EOS.undent

--- a/gal-sim.rb
+++ b/gal-sim.rb
@@ -30,8 +30,8 @@ class GalSim < Formula
       end
       args << "WITH_OPENMP=true"
     end
-    scons *args
-    scons "install", "PREFIX=#{prefix}", "PYPREFIX=#{lib}/python#{pyver}", "EXTRA_INCLUDE_PATH=#{HOMEBREW_PREFIX}/include", "EXTRA_LIB_PATH=#{HOMEBREW_PREFIX}/lib", "EXTRA_PATH=#{HOMEBREW_PREFIX}/bin"
+    scons "EXTRA_INCLUDE_PATH=#{HOMEBREW_PREFIX}/include", "EXTRA_LIB_PATH=#{HOMEBREW_PREFIX}/lib", "EXTRA_PATH=#{HOMEBREW_PREFIX}/bin", *args
+    scons "install", "PREFIX=#{prefix}", "PYPREFIX=#{lib}/python#{pyver}"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
As reported in #2577 ; this version is reported to work by OP

