### PR TITLE
Update gromacs.rb to latest stable version (5.0.6)

### DIFF
--- a/gromacs.rb
+++ b/gromacs.rb
@@ -3,8 +3,9 @@ require "formula"
 class Gromacs < Formula
   homepage "http://www.gromacs.org/"
   version "5.0.6"
+  desc "GROMACS is a versatile package for performing molecular dynamics calculations, i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles, primarily proteins, lipids, and nucleic acids."
   url "ftp://ftp.gromacs.org/pub/gromacs/gromacs-5.0.6.tar.gz"
-  mirror "http://fossies.org/linux/privat/gromacs-5.0.6.tar.gz"
+  mirror "https://fossies.org/linux/privat/gromacs-5.0.6.tar.gz"
   sha256 "e07e950c4cd6cb84b83b145b70a15c25338ad6a7d7d1a0a83cdbd51cad954952"
 
   deprecated_option "with-x" => "with-x11"
@@ -26,13 +27,11 @@ class Gromacs < Formula
     args << "-DGMX_DOUBLE=ON" if build.include? "enable-double"
     args << "-DGMX_X11=ON" if build.with? "x11"
     args << "-DGMX_CPU_ACCELERATION=None" if MacOS.version <= :snow_leopard
-    args << "-DREGRESSIONTEST_DOWNLOAD=ON" unless build.with? "without-check"
+    args << "-DREGRESSIONTEST_DOWNLOAD=ON" if build.with? "check"
 
     inreplace "scripts/CMakeLists.txt", "BIN_INSTALL_DIR", "DATA_INSTALL_DIR"
 
-    system "mkdir", "build"
-
-    cd "build" do
+    mkdir "build" do
       system "cmake", "..", *args
       system "make"
       system "make", "check" if build.with? "check"

--- a/gromacs.rb
+++ b/gromacs.rb
@@ -40,8 +40,8 @@ class Gromacs < Formula
 
     # This is a really hacky solution, but seems needed to pass Homebrew build test
     # Doesn't seem to affect command line completion of built package
-    rm "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion-gmx.bash"
-    rm "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion.bash"
+    rm "#{bin}/gmx-completion-gmx.bash"
+    rm "#{bin}/gmx-completion.bash"
 
     bash_completion.install "build/scripts/GMXRC" => "gromacs-completion.bash"
     zsh_completion.install "build/scripts/GMXRC.zsh" => "_gromacs"

--- a/gromacs.rb
+++ b/gromacs.rb
@@ -2,7 +2,6 @@ require "formula"
 
 class Gromacs < Formula
   homepage "http://www.gromacs.org/"
-  version "5.0.6"
   desc "GROMACS is a versatile package for performing molecular dynamics calculations, i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles, primarily proteins, lipids, and nucleic acids."
   url "ftp://ftp.gromacs.org/pub/gromacs/gromacs-5.0.6.tar.gz"
   mirror "https://fossies.org/linux/privat/gromacs-5.0.6.tar.gz"
@@ -38,6 +37,10 @@ class Gromacs < Formula
       ENV.deparallelize
       system "make", "install"
     end
+
+    # This is a really hacky solution, but seems needed to pass Homebrew build test
+    # Doesn't seem to affect command line completion of built package
+    system "rm", "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion-gmx.bash", "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion.bash"
 
     bash_completion.install "build/scripts/GMXRC" => "gromacs-completion.bash"
     zsh_completion.install "build/scripts/GMXRC.zsh" => "_gromacs"

--- a/gromacs.rb
+++ b/gromacs.rb
@@ -2,9 +2,10 @@ require "formula"
 
 class Gromacs < Formula
   homepage "http://www.gromacs.org/"
-  url "ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.5.tar.gz"
-  mirror "https://fossies.org/linux/privat/gromacs-4.6.5.tar.gz"
-  sha1 "6bf86bb514e5488bda988d5b0e98867706d4ecd4"
+  version "5.0.6"
+  url "ftp://ftp.gromacs.org/pub/gromacs/gromacs-5.0.6.tar.gz"
+  mirror "http://fossies.org/linux/privat/gromacs-5.0.6.tar.gz"
+  sha256 "e07e950c4cd6cb84b83b145b70a15c25338ad6a7d7d1a0a83cdbd51cad954952"
 
   deprecated_option "with-x" => "with-x11"
   deprecated_option "enable-mpi" => "with-mpi"
@@ -25,19 +26,22 @@ class Gromacs < Formula
     args << "-DGMX_DOUBLE=ON" if build.include? "enable-double"
     args << "-DGMX_X11=ON" if build.with? "x11"
     args << "-DGMX_CPU_ACCELERATION=None" if MacOS.version <= :snow_leopard
+    args << "-DREGRESSIONTEST_DOWNLOAD=ON" unless build.with? "without-check"
 
     inreplace "scripts/CMakeLists.txt", "BIN_INSTALL_DIR", "DATA_INSTALL_DIR"
 
-    cd "src" do
+    system "mkdir", "build"
+
+    cd "build" do
       system "cmake", "..", *args
       system "make"
-      system "make", "test" if build.with? "check"
+      system "make", "check" if build.with? "check"
       ENV.deparallelize
       system "make", "install"
     end
 
-    bash_completion.install "scripts/completion.bash" => "gromacs-completion.bash"
-    zsh_completion.install "scripts/completion.zsh" => "_gromacs"
+    bash_completion.install "build/scripts/GMXRC" => "gromacs-completion.bash"
+    zsh_completion.install "build/scripts/GMXRC.zsh" => "_gromacs"
   end
 
   def caveats;  <<-EOS.undent

--- a/gromacs.rb
+++ b/gromacs.rb
@@ -40,7 +40,8 @@ class Gromacs < Formula
 
     # This is a really hacky solution, but seems needed to pass Homebrew build test
     # Doesn't seem to affect command line completion of built package
-    system "rm", "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion-gmx.bash", "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion.bash"
+    rm "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion-gmx.bash"
+    rm "/usr/local/Cellar/gromacs/5.0.6/bin/gmx-completion.bash"
 
     bash_completion.install "build/scripts/GMXRC" => "gromacs-completion.bash"
     zsh_completion.install "build/scripts/GMXRC.zsh" => "_gromacs"

--- a/gromacs.rb
+++ b/gromacs.rb
@@ -38,12 +38,9 @@ class Gromacs < Formula
       system "make", "install"
     end
 
-    # This is a really hacky solution, but seems needed to pass Homebrew build test
-    # Doesn't seem to affect command line completion of built package
-    rm "#{bin}/gmx-completion-gmx.bash"
-    rm "#{bin}/gmx-completion.bash"
-
     bash_completion.install "build/scripts/GMXRC" => "gromacs-completion.bash"
+    bash_completion.install "#{bin}/gmx-completion-gmx.bash" => "gmx-completion-gmx.bash"
+    bash_completion.install "#{bin}/gmx-completion.bash" => "gmx-completion.bash"
     zsh_completion.install "build/scripts/GMXRC.zsh" => "_gromacs"
   end
 


### PR DESCRIPTION
Previous version was not linking gmx binary to the path. Should now
build, test, and install Gromacs suite (test on by default) and link all
binaries to the path.

Also note: While the project preferred method for downloading Gromacs is
via a box.com link (see http://www.gromacs.org/downloads), Homebrew does
not seem able to unpack files downloaded via this method. Direct FTP
download was therefore maintained in this update. Requires further
looking into.