### PR TITLE
r: Linuxbrew fix

### DIFF
--- a/r.rb
+++ b/r.rb
@@ -66,6 +66,7 @@ class R < Formula
 
     args = [
       "--prefix=#{prefix}",
+      "--libdir=#{lib}",
       "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}",
       "--enable-memory-profiling",
     ]


### PR DESCRIPTION
On 64-bit Linux the libdir will be set to lib64 but the recipe expects
it to match #{lib}.