### PR TITLE
hwloc: Depends on :x11

### DIFF
--- a/hwloc.rb
+++ b/hwloc.rb
@@ -20,6 +20,7 @@ class Hwloc < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cairo" => :optional
+  depends_on :x11
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
Build will fail without this dependency since it tries to link with libX11.