### PR TITLE
Gmsh and dealii. Bump revision for new version of opencascade

### DIFF
--- a/dealii.rb
+++ b/dealii.rb
@@ -3,6 +3,7 @@ class Dealii < Formula
   homepage "http://www.dealii.org"
   url "https://github.com/dealii/dealii/releases/download/v8.3.0/dealii-8.3.0.tar.gz"
   sha256 "4ddf72632eb501e1c814e299f32fc04fd680d6fda9daff58be4209e400e41779"
+  revision 1
 
   bottle do
     sha256 "65b1d02766fa92cd6c1796c3bd06ea5cfc7736f013416a309b006b1c0036b89a" => :yosemite

--- a/gmsh.rb
+++ b/gmsh.rb
@@ -11,6 +11,7 @@ class Gmsh < Formula
   sha256 "10db05a73bf7f05f6663ddb3b76045ce9decb28b36ad2e54547861254829a860"
 
   head "https://geuz.org/svn/gmsh/trunk", :using => GmshSvnStrategy
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
Upgrading Opencascade to 6.9.0 broke the bottle of gmsh

```
dyld: Symbol not found: __ZN15Adaptor3d_Curve6DeleteEv
  Referenced from: /usr/local/bin/gmsh
  Expected in: /usr/local/opt/opencascade/mac64/clang/lib/libTKG3d.dylib
 in /usr/local/bin/gmsh
Trace/BPT trap: 5
```

I have not tested dealii but I assume the same is the case here.

These are the 2 only dependencies of opencascade in homebrew science