### PR TITLE
Trilinos 12.2.1 (fix)

### DIFF
--- a/trilinos.rb
+++ b/trilinos.rb
@@ -268,8 +268,10 @@ class Trilinos < Formula
       # against the libraries listed in Trilinos_LIBRARIES.
       # See https://github.com/Homebrew/homebrew-science/issues/2148#issuecomment-103614509
       # A workaround it to remove PyTrilinos from the COMPONENTS_LIST :
-      inreplace "#{lib}/cmake/Trilinos/TrilinosConfig.cmake" do |s|
-        s.gsub! "PyTrilinos;", "" if s.include? "COMPONENTS_LIST"
+      if build.with? "python"
+        inreplace "#{lib}/cmake/Trilinos/TrilinosConfig.cmake" do |s|
+          s.gsub! "PyTrilinos;", "" if s.include? "COMPONENTS_LIST"
+        end
       end
     end
   end


### PR DESCRIPTION
wipe PyTrilinos from .cmake file only when build.with? python.

Otherwise
```
Error: inreplace failed
.linuxbrew/Cellar/trilinos/12.2.1/lib/cmake/Trilinos/TrilinosConfig.cmake:
  expected replacement of "PyTrilinos;" with ""
```