### PR TITLE
insighttoolkit 4.8.1

### DIFF
--- a/insighttoolkit.rb
+++ b/insighttoolkit.rb
@@ -1,8 +1,8 @@
 class Insighttoolkit < Formula
   desc "ITK is a toolkit for performing registration and segmentation"
   homepage "http://www.itk.org"
-  url "https://downloads.sourceforge.net/project/itk/itk/4.8/InsightToolkit-4.8.0.tar.gz"
-  sha256 "8de5081f81707faf0cddd42f7eeea9498ce790672eb382a0d72b153623dca08a"
+  url "https://downloads.sourceforge.net/project/itk/itk/4.8/InsightToolkit-4.8.1.tar.gz"
+  sha256 "1aff73f6e2f43e06814258f2ebaec5e1010316c8d7d72ecb2944a85661f6303d"
   head "git://itk.org/ITK.git"
 
   bottle do
@@ -18,6 +18,7 @@ class Insighttoolkit < Formula
   depends_on "vtk" => [:build] + cxx11dep
   depends_on "opencv" => [:optional] + cxx11dep
   depends_on :python => :optional
+  depends_on :python3 => :optional
   depends_on "fftw" => :recommended
   depends_on "hdf5" => [:recommended] + cxx11dep
   depends_on "jpeg" => :recommended
@@ -42,9 +43,7 @@ class Insighttoolkit < Formula
       -DITK_USE_SYSTEM_ZLIB=ON
       -DCMAKE_INSTALL_RPATH:STRING=#{lib}
       -DCMAKE_INSTALL_NAME_DIR:STRING=#{lib}
-      -DModule_ITKLevelSetsv4Visualization=ON
       -DModule_SCIFIO=ON
-      -DModule_ITKReview=ON
     ]
     args << ".."
     args << "-DBUILD_EXAMPLES=" + ((build.include? "examples") ? "ON" : "OFF")
@@ -59,18 +58,30 @@ class Insighttoolkit < Formula
     args << "-DITK_USE_SYSTEM_GDCM=ON" if build.with? "gdcm"
     args << "-DITK_LEGACY_REMOVE=ON" if build.include? "remove-legacy"
 
+    # These 3 modules are not supported with python3. Set them to OFF in this case.
+    args << "-DModule_ITKLevelSetsv4Visualization=" + ((build.with? "python3") ? "OFF" : "ON")
+    args << "-DModule_ITKReview=" + ((build.with? "python3") ? "OFF" : "ON")
+    args << "-DModule_ITKVtkGlue=" + ((build.with? "python3") ? "OFF" : "ON")
+
     args << "-DVCL_INCLUDE_CXX_0X=ON" if build.cxx11?
     ENV.cxx11 if build.cxx11?
 
     mkdir "itk-build" do
-      if build.with? "python"
-        args += %W[
-          -DITK_WRAP_PYTHON=ON
-          -DModule_ITKVtkGlue=ON
-        ]
+      if build.with? "python" or build.with? "python3"
+
+        args << "-DITK_WRAP_PYTHON=ON"
+
         # CMake picks up the system's python dylib, even if we have a brewed one.
-        args << "-DPYTHON_LIBRARY='#{%x(python-config --prefix).chomp}/lib/libpython2.7.dylib'"
-        args << "-DPYTHON_INCLUDE_DIR='#{%x(python-config --prefix).chomp}/include/python2.7'"
+        if build.with? "python"
+          args << "-DPYTHON_LIBRARY='#{%x(python-config --prefix).chomp}/lib/libpython2.7.dylib'"
+          args << "-DPYTHON_INCLUDE_DIR='#{%x(python-config --prefix).chomp}/include/python2.7'"
+        elsif build.with? "python3"
+          ENV["PYTHONPATH"] = lib/"python3.5/site-packages"
+          args << "-DPYTHON_EXECUTABLE='#{%x(python3-config --prefix).chomp}/bin/python3'"
+          args << "-DPYTHON_LIBRARY='#{%x(python3-config --prefix).chomp}/lib/libpython3.5.dylib'"
+          args << "-DPYTHON_INCLUDE_DIR='#{%x(python3-config --prefix).chomp}/include/python3.5m'"
+        end
+
       end
       system "cmake", *args
       system "make", "install"


### PR DESCRIPTION
Adds support for python 3 wrapping

Module_ITKLevelSetsv4Visualization, Module_ITKReview and Module_ITKVtkGlue can be build without python or with python2 . They can not be built with python3 because VTK does not support python3 for the moment (though they are working on it).