### PR TITLE
root6 6.04.06

### DIFF
--- a/root6.rb
+++ b/root6.rb
@@ -1,12 +1,12 @@
 class Root6 < Formula
   # in order to update, simply change version number and update sha256
-  version_number = "6.04.04"
+  version_number = "6.04.06"
   desc "Object oriented framework for large scale data analysis"
   homepage "http://root.cern.ch"
-  url "http://root.cern.ch/download/root_v#{version_number}.source.tar.gz"
+  url "https://root.cern.ch/download/root_v#{version_number}.source.tar.gz"
   mirror "https://fossies.org/linux/misc/root_v#{version_number}.source.tar.gz"
   version version_number
-  sha256 "65620a7c15c6575794ee58749e409f8562d5a64e58443cfc2d55f5eb962a0562"
+  sha256 "6deac9cd71fe2d7a48ea2bcbd793639222c4743275dbc946c158295b1e1fe330"
   head "http://root.cern.ch/git/root.git"
 
   bottle do


### PR DESCRIPTION
Includes various fixes for OS X 10.11, described in the [release notes](https://root.cern.ch/root/html604/notes/release-notes.html#release-6.0406).