### PR TITLE
Bump graph-tool version to 2.10

### DIFF
--- a/graph-tool.rb
+++ b/graph-tool.rb
@@ -1,7 +1,7 @@
 class GraphTool < Formula
   homepage "http://graph-tool.skewed.de/"
-  url "http://downloads.skewed.de/graph-tool/graph-tool-2.9.tar.bz2"
-  sha256 "d3df98adc8a7ea6202e270b62c05825a483fc08c51000721356971d76af1146e"
+  url "http://downloads.skewed.de/graph-tool/graph-tool-2.10.tar.bz2"
+  sha256 "1569a0dbb28f5a09efd86dad058b1729a4c1aaed3ca76b99723298871f5be2d4"
 
   head do
     url "https://github.com/count0/graph-tool.git"

--- a/graph-tool.rb
+++ b/graph-tool.rb
@@ -50,6 +50,10 @@ class GraphTool < Formula
     depends_on "pygobject3" => with_pythons
   end
 
+  fails_with :clang => '3.5' do
+    cause "seems to have insuficient C++14 support"
+  end
+
   def install
     ENV.cxx11
 


### PR DESCRIPTION
Note that since version 2.9 graph-tool actually requires C++14. But I'm not sure that one should replace the cxx11 homebrew option.