### PR TITLE
Restore galsim v1.3.0

### DIFF
--- a/galsim.rb
+++ b/galsim.rb
@@ -1,8 +1,8 @@
 class Galsim < Formula
   desc "The modular galaxy image simulation toolkit"
   homepage "https://github.com/GalSim-developers/GalSim"
-  url "https://github.com/GalSim-developers/GalSim/archive/v1.2.0.tar.gz"
-  sha256 "b8aee165da579074a8ca5e921b89d9aab8b17cfcf5f1d3ea3d81e897d53b2e47"
+  url "https://github.com/GalSim-developers/GalSim/archive/v1.3.0.tar.gz"
+  sha256 "4afd3284adfd12845b045ea3c8e293b63057c7da57872bc9eecd005cf0a763c0"
   head "https://github.com/GalSim-developers/GalSim.git"
 
   option "with-openmp", "Enable openmp support (gcc only)"
@@ -38,7 +38,7 @@ class Galsim < Formula
     end
     scons *args
     scons "tests"
-    scons "install", "PREFIX=#{prefix}", "PYPREFIX=#{lib}/python#{pyver}"
+    scons "install", "PREFIX=#{prefix}", "PYPREFIX=#{lib}/python#{pyver}/site-packages"
     pkgshare.install "examples"
   end
 


### PR DESCRIPTION
It looks like https://github.com/Homebrew/homebrew-science/commit/02b09555d6f7538b4ce45979a391470dffbc5a2d accidentally downgraded galsim from v1.3.0 to v1.2.0.

I also changed the Python install line such that galsim gets installed in `site-packages`. (i.e. It is immediately importable from a brewed Python after `brew install galsim`.) There may be a better way to do this, but a cursory search for best practices was inconclusive. (Presumably a symlink or `.pth` file would work just as well, but I don't know what's preferred.)