### PR TITLE
Update glpk 4.57, fix test

### DIFF
--- a/glpk.rb
+++ b/glpk.rb
@@ -1,4 +1,5 @@
 class Glpk < Formula
+  desc "GLPK (GNU Linear Programming Kit) solves Linear Programming (LP) and Mixed Integer Programming (MIP) problems"
   homepage "https://www.gnu.org/software/glpk/"
   url "http://ftpmirror.gnu.org/glpk/glpk-4.57.tar.gz"
   mirror "https://ftp.gnu.org/gnu/glpk/glpk-4.57.tar.gz"

--- a/glpk.rb
+++ b/glpk.rb
@@ -1,8 +1,8 @@
 class Glpk < Formula
   homepage "https://www.gnu.org/software/glpk/"
-  url "http://ftpmirror.gnu.org/glpk/glpk-4.52.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/glpk/glpk-4.52.tar.gz"
-  sha1 "44b30b0de777a0a07e00615ac6791af180ff4d2c"
+  url "http://ftpmirror.gnu.org/glpk/glpk-4.57.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/glpk/glpk-4.57.tar.gz"
+  sha256 "7323b2a7cc1f13e45fc845f0fdca74f4daea2af716f5ad2d4d55b41e8394275c"
 
   bottle do
     cellar :any
@@ -34,7 +34,7 @@ class Glpk < Formula
         return 0;
     }
     EOF
-    system ENV.cc, "test.c", "-lglpk", "-o", "test"
+    system ENV.cc, "test.c", "-L/usr/local/lib", "-I/usr/local/include", "-lglpk", "-o", "test"
     assert_equal `./test`, version.to_s
   end
 end


### PR DESCRIPTION
Updated to the latest glpk 4.57.  Fixed the test so that it does not assume that /usr/local/lib and /usr/local/include are in the search path for the compiler