### PR TITLE
opencv3: Add VTK option

### DIFF
--- a/opencv3.rb
+++ b/opencv3.rb
@@ -37,6 +37,7 @@ class Opencv3 < Formula
   option "with-qt", "Build the Qt4 backend to HighGUI"
   option "with-qt5", "Build the Qt5 backend to HighGUI"
   option "with-tbb", "Enable parallel code in OpenCV using Intel TBB"
+  option "with-vtk", "Build with VTK support"
   option "without-numpy", "Use a numpy you've installed yourself instead of a Homebrew-packaged numpy"
   option "without-opencl", "Disable GPU code in OpenCV using OpenCL"
   option "without-python", "Build without Python support"
@@ -67,6 +68,7 @@ class Opencv3 < Formula
   depends_on "qt" => :optional
   depends_on "qt5" => :optional
   depends_on "tbb" => :optional
+  depends_on "vtk" => :optional
 
   with_python = build.with?("python") || build.with?("python3")
   pythons = build.with?("python3") ? ["with-python3"] : []
@@ -121,6 +123,7 @@ class Opencv3 < Formula
     args << "-DWITH_QUICKTIME=" + arg_switch("quicktime")
     args << "-DWITH_QT=" + (with_qt ? "ON" : "OFF")
     args << "-DWITH_TBB=" + arg_switch("tbb")
+    args << "-DWITH_VTK=" + arg_switch("vtk")
 
     if build.include? "32-bit"
       args << "-DCMAKE_OSX_ARCHITECTURES=i386"

--- a/opencv3.rb
+++ b/opencv3.rb
@@ -37,7 +37,6 @@ class Opencv3 < Formula
   option "with-qt", "Build the Qt4 backend to HighGUI"
   option "with-qt5", "Build the Qt5 backend to HighGUI"
   option "with-tbb", "Enable parallel code in OpenCV using Intel TBB"
-  option "with-vtk", "Build with VTK support"
   option "without-numpy", "Use a numpy you've installed yourself instead of a Homebrew-packaged numpy"
   option "without-opencl", "Disable GPU code in OpenCV using OpenCL"
   option "without-python", "Build without Python support"

--- a/opencv3.rb
+++ b/opencv3.rb
@@ -1,6 +1,7 @@
 class Opencv3 < Formula
   desc "Open source computer vision library, version 3"
   homepage "http://opencv.org/"
+  revision 1
 
   stable do
     url "https://github.com/Itseez/opencv/archive/3.1.0.tar.gz"


### PR DESCRIPTION
VTK is required for the opencv_viz module
Same as #3176 for opencv3