### PR TITLE
updated to cmdstan 2.9.0

### DIFF
--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -10,19 +10,19 @@ class Cmdstan < Formula
 
   # tag "math"
 
-  url "https://github.com/stan-dev/cmdstan/releases/download/v2.7.0/cmdstan-2.7.0.tar.gz"
-  sha256 "8f8f119a88327a7cef9829cb593a1d726a65c6bc37cc85ef11f5442add31d9e1"
+  url "https://github.com/stan-dev/cmdstan/releases/download/v2.9.0/cmdstan-2.9.0.tar.gz"
+  sha256 "a9f2858caa5b55576da85ef31b4eae632c97837aa042514242a9aad7ada97121"
 
   depends_on "boost"
   depends_on "eigen"
 
   def install
     system "make", "build"
-    bin.install "bin/print" => "stansummary"
+    bin.install "bin/stansummary"
     bin.install "bin/stanc"
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md", "examples"
-    include.install "stan/src/stan"
-    (include/"stan").install Dir["stan/lib/stan_math_*/stan/*"]
+    include.install "stan_2.9.0/src/stan"
+    (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
   end
 
   test do

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -19,19 +19,23 @@ class Cmdstan < Formula
   def install
     system "make", "build"
 
-    # symlink the two commands
+    # symlink the two commands. These are the only ones that should be symlinked to main bin dir.
     bin.install "bin/stansummary" 
     bin.install "bin/stanc"
 
     # But we need more from the bin dir...
-    bin.install Dir["bin/*"] # This copies over all of the rest of the bin dir but also symlinks ;)
-	
+    # This copies over all of the rest of the bin dir but also (erroneously) 
+    # symlinks print and libstanc.a. Not sure how to avoid that.
+    bin.cp Dir["bin/*"]
+
+    # Install docs	
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md"
 
     # For the standard stan make system to work we need the following files in prefix:
     prefix.install "src", "makefile", "make", "stan_2.9.0", "examples"
 
-	  (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
+    # This cannot be done after the prefix.install of "stan_2.9.0" since the files are no longer around...
+	  # (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
   end
 
   test do

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -23,10 +23,14 @@ class Cmdstan < Formula
     bin.install "bin/stansummary"
     bin.install "bin/stanc"
 
-    # But we need more from the bin dir...
-    # This copies over all of the rest of the bin dir but also (erroneously)
-    # symlinks print and libstanc.a. Not sure how to avoid that.
-    bin.install Dir["bin/*"]
+    # But unfortunately we need more from the bin dir since cmdstan uses the makefile
+    # in the prefix dir when building executables for each new stan model. In order for that
+    # makefiel to work it needs the object files that the cmdstan currently saves in the bin dir.
+    # This makes it hard to change the structure of these files unless other tools that depend on
+    # cmdstan also change. The print file that is copied
+    bin.install "bin/libstanc.a"
+    (bin/"cmdstan").install Dir["bin/cmdstan/*"]
+    (bin/"stan").install Dir["bin/stan/*"]
 
     # Install docs
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md"

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -20,22 +20,22 @@ class Cmdstan < Formula
     system "make", "build"
 
     # symlink the two commands. These are the only ones that should be symlinked to main bin dir.
-    bin.install "bin/stansummary" 
+    bin.install "bin/stansummary"
     bin.install "bin/stanc"
 
     # But we need more from the bin dir...
-    # This copies over all of the rest of the bin dir but also (erroneously) 
+    # This copies over all of the rest of the bin dir but also (erroneously)
     # symlinks print and libstanc.a. Not sure how to avoid that.
     bin.install Dir["bin/*"]
 
-    # Install docs	
+    # Install docs
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md"
 
     # For the standard stan make system to work we need the following files in prefix:
     prefix.install "src", "makefile", "make", "stan_2.9.0", "examples"
 
     # This cannot be done after the prefix.install of "stan_2.9.0" since the files are no longer around...
-	  # (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
+    # (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
   end
 
   test do

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -18,11 +18,20 @@ class Cmdstan < Formula
 
   def install
     system "make", "build"
-    bin.install "bin/stansummary"
+
+    # symlink the two commands
+    bin.install "bin/stansummary" 
     bin.install "bin/stanc"
-    doc.install "CONTRIBUTING.md", "LICENSE", "README.md", "examples"
-    prefix.install "stan_2.9.0"
-    (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
+
+    # But we need more from the bin dir...
+    bin.install Dir["bin/*"] # This copies over all of the rest of the bin dir but also symlinks ;)
+	
+    doc.install "CONTRIBUTING.md", "LICENSE", "README.md"
+
+    # For the standard stan make system to work we need the following files in prefix:
+    prefix.install "src", "makefile", "make", "stan_2.9.0", "examples"
+
+	  (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
   end
 
   test do

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -70,6 +70,6 @@ class Cmdstan < Formula
     system "#{bin}/stanc", "--version"
     cp prefix/"examples/bernoulli/bernoulli.stan", "."
     system "#{bin}/stanc", "bernoulli.stan"
-    system "make", "bernoulli_model.o", "CPPFLAGS=-I#{Formula["eigen"].include/"eigen3"} -I#{prefix + "stan_2.9.0/src"} -I#{prefix + "stan_2.9.0/lib/stan_math_2.9.0"}"
+    system "make", "bernoulli_model.o", "CPPFLAGS=-I#{Formula["eigen"].include/"eigen3"} -I#{prefix}/stan_2.9.0/src -I#{prefix}/stan_2.9.0/lib/stan_math_2.9.0"
   end
 end

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -1,17 +1,16 @@
 class Cmdstan < Formula
-  desc "Probabilistic programming language for Bayesian inference"
+  desc "Probabilistic programming for Bayesian inference"
   homepage "http://mc-stan.org/"
+  # tag "math"
+  url "https://github.com/stan-dev/cmdstan/releases/download/v2.9.0/cmdstan-2.9.0.tar.gz"
+  sha256 "a9f2858caa5b55576da85ef31b4eae632c97837aa042514242a9aad7ada97121"
+
   bottle do
     cellar :any
     sha256 "a6c23277dcc15ce6c70f3b50b7e3cdc749d0b83139fb7de270e36564a70a6460" => :yosemite
     sha256 "0fac67e14fb25191104c09df25ca437d891104925f56aa307b0e650dc7d07b96" => :mavericks
     sha256 "336473380148fd20886c8fcb68538a4cbc77daa52c1a515d5bcb3f4793cfe1db" => :mountain_lion
   end
-
-  # tag "math"
-
-  url "https://github.com/stan-dev/cmdstan/releases/download/v2.9.0/cmdstan-2.9.0.tar.gz"
-  sha256 "a9f2858caa5b55576da85ef31b4eae632c97837aa042514242a9aad7ada97121"
 
   depends_on "boost"
   depends_on "eigen"

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -21,7 +21,7 @@ class Cmdstan < Formula
     bin.install "bin/stansummary"
     bin.install "bin/stanc"
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md", "examples"
-    include.install "stan_2.9.0/src/stan"
+    prefix.install "stan_2.9.0"
     (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
   end
 

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -68,6 +68,8 @@ class Cmdstan < Formula
 
   test do
     system "#{bin}/stanc", "--version"
-    system "make", "examples/bernoulli/bernoulli"
+    cp prefix/"examples/bernoulli/bernoulli.stan", "."
+    system "#{bin}/stanc", "bernoulli.stan"
+    system "make", "bernoulli_model.o", "CPPFLAGS=-I#{Formula["eigen"].include/"eigen3"} -I#{prefix + "stan_2.9.0/src"} -I#{prefix + "stan_2.9.0/lib/stan_math_2.9.0"}"
   end
 end

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -17,36 +17,21 @@ class Cmdstan < Formula
   depends_on "eigen"
 
   def install
-    system "make", "build"
+    #
+    # Before we build we need to change the make files since cmdstan builds more than binaries
+    # into the bin dir. This is not how homebrew prefers things and we were recommended
+    # by homebrew-science maintainers to change the makefiles to rather build from and to lib.
+    # We need to change in 3 make files below.
+    #
 
-    # symlink the two commands. These are the only ones that should be symlinked to main bin dir.
-    bin.install "bin/stansummary"
-    bin.install "bin/stanc"
-
-    # But unfortunately we need more from the bin dir since cmdstan uses the makefile
-    # in the prefix dir when building executables for each new stan model. In order for that
-    # makefiel to work it needs the object files that the cmdstan currently saves in the bin dir.
-    # This makes it hard to change the structure of these files unless other tools that depend on
-    # cmdstan also change. The print file that is copied
-    #bin.install "bin/libstanc.a"
-    #(bin/"cmdstan").install Dir["bin/cmdstan/*"]
-    #(bin/"stan").install Dir["bin/stan/*"]
-
-    # If we change the makefile we can move the files that cmdstan normally installs to bin in lib.
-    # This was recommended by the homebrew-science maintainers as the preferred way since homebrew
-    # do not want non-executable files installed into bin.
-    lib.install "bin/libstanc.a"
-    (lib/"cmdstan").install Dir["bin/cmdstan/*"]
-    (lib/"stan").install Dir["bin/stan/*"]
-
-    # We need to change make/command file so that lines with "bin/cmdstand" instead uses
+    # 1. We need to change make/command file so that lines with "bin/cmdstand" instead uses
     # "lib/cmdstan" and that the libstanc.a library has a lib instead of a bin path:
     inreplace "make/command" do |s|
       s.gsub! "bin/cmdstan/", "lib/cmdstan/"
       s.gsub! "bin/libstanc.a", "lib/libstanc.a"
     end
 
-    # We need to change make/libstan so that libstanc.a is referred to via a lib path instead of a
+    # 2. We need to change make/libstan so that libstanc.a is referred to via a lib path instead of a
     # bin path:
     inreplace "make/libstan" do |s|
       s.gsub! "bin/libstanc.a", "lib/libstanc.a"
@@ -54,7 +39,7 @@ class Cmdstan < Formula
       s.gsub! "src/%.cpp=bin/%.o", "src/%.cpp=lib/%.o"
     end
 
-    # Several corresponding changes in the main makefile:
+    # 3. Several corresponding changes in the main makefile:
     inreplace "makefile" do |s|
       s.gsub! "LDLIBS_STANC = -Lbin", "LDLIBS_STANC = -Llib"
       s.gsub! "bin/%.o", "lib/%.o"
@@ -63,20 +48,27 @@ class Cmdstan < Formula
       s.gsub! "bin/%.d", "lib/%.d"
     end
 
+    # Now we can build:
+    system "make", "build"
+
+    # And install and symlink the commands.
+    bin.install "bin/stansummary"
+    bin.install "bin/stanc"
+    bin.install "bin/print" # Include it for now, it will be obsolete in cmdstan 3.0 but some people might still use it
+
+    # Now install the lib dir with the built object and lib files. They are needed later when we
+    # build executables for specific Stan models.
+    lib.install Dir["lib/*"]
+
     # Install docs
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md"
 
-    # For the standard stan make system to work we need the following files in prefix:
+    # For the standard stan make system to work we also need the following files in prefix:
     prefix.install "src", "makefile", "make", "stan_2.9.0", "examples"
-
-    # This cannot be done after the prefix.install of "stan_2.9.0" since the files are no longer around...
-    # (include/"stan").install Dir["stan_2.9.0/lib/stan_math_*/stan/*"]
   end
 
   test do
     system "#{bin}/stanc", "--version"
-    cp doc/"examples/bernoulli/bernoulli.stan", "."
-    system "#{bin}/stanc", "bernoulli.stan"
-    system "make", "bernoulli_model.o", "CPPFLAGS=-I#{Formula["eigen"].include/"eigen3"}"
+    system "make", "examples/bernoulli/bernoulli"
   end
 end

--- a/cmdstan.rb
+++ b/cmdstan.rb
@@ -26,7 +26,7 @@ class Cmdstan < Formula
     # But we need more from the bin dir...
     # This copies over all of the rest of the bin dir but also (erroneously) 
     # symlinks print and libstanc.a. Not sure how to avoid that.
-    bin.cp Dir["bin/*"]
+    bin.install Dir["bin/*"]
 
     # Install docs	
     doc.install "CONTRIBUTING.md", "LICENSE", "README.md"


### PR DESCRIPTION
Changed from version 2.7.0 to 2.9.0. The dirs had changed and I use new stansummary instead of renaming print since from cmdstan 3.0 there will be no print command, only stansummary.