### PR TITLE
vips: Add libjpeg-turbo support and bugfixes

### DIFF
--- a/vips.rb
+++ b/vips.rb
@@ -2,6 +2,7 @@ class Vips < Formula
   homepage "http://www.vips.ecs.soton.ac.uk/"
   url "http://www.vips.ecs.soton.ac.uk/supported/8.2/vips-8.2.1.tar.gz"
   sha256 "bcedee8cd654b26591e08c7085758764358c12fdf1a2141cd5e539a046365928"
+  revision 1
 
   bottle do
     sha256 "41a5deab9c91f1af826213d3cb4ceb650084cc376e5e0107b64c1f12e2902142" => :el_capitan
@@ -38,6 +39,11 @@ class Vips < Formula
   depends_on "python3" => :optional
   depends_on "libmatio" => :optional
   depends_on "mozjpeg" => :optional
+  depends_on "jpeg-turbo" => :optional
+
+  # Bugfix from commit 4512400 for bilinear interpolation rounding error.
+  # Remove when 8.2.2 is released.
+  patch :DATA
 
   def install
     args = %W[
@@ -47,7 +53,11 @@ class Vips < Formula
     args.concat %w[--with-magick --with-magickpackage=GraphicsMagick] if build.with? "graphicsmagick"
 
     system "./configure", *args
-    system "make", "check" if build.with? "check"
+    if build.with? "check"
+      # Test scripts fail with non-english decimal separator, see jcupitt/libvips#367
+      ENV["LC_NUMERIC"] = "C"
+      system "make", "check"
+    end
     system "make", "install"
   end
 
@@ -56,3 +66,19 @@ class Vips < Formula
     system "#{bin}/vipsheader", test_fixtures("test.png")
   end
 end
+
+__END__
+diff --git a/libvips/resample/interpolate.c b/libvips/resample/interpolate.c
+index 52d24dc..354c8a9 100644
+--- a/libvips/resample/interpolate.c
++++ b/libvips/resample/interpolate.c
+@@ -430,7 +430,8 @@ G_DEFINE_TYPE( VipsInterpolateBilinear, vips_interpolate_bilinear,
+ 
+ #define BILINEAR_INT_INNER { \
+ 	tq[z] = (sc1 * tp1[z] + sc2 * tp2[z] + \
+-		 sc3 * tp3[z] + sc4 * tp4[z]) >> VIPS_INTERPOLATE_SHIFT; \
++		 sc3 * tp3[z] + sc4 * tp4[z] + \
++		 (1 << VIPS_INTERPOLATE_SHIFT) / 2) >> VIPS_INTERPOLATE_SHIFT; \
+ 	z += 1; \
+ }
+ 


### PR DESCRIPTION
* Support `--with-jpeg-turbo` to compile against libjpeg-turbo
* Backport bilinear interpolation rounding fix (will be in 8.2.2, see jcupitt/libvips@4512400a3ced2237fa2e4c3169d5f26a4adf4e3b)
* Fix `make check` with comma decimal separator (jcupitt/libvips#367)