### PR TITLE
BEDOPS 2.4.15

### DIFF
--- a/bedops.rb
+++ b/bedops.rb
@@ -6,6 +6,7 @@ class Bedops < Formula
   url "https://github.com/bedops/bedops/archive/v2.4.15.tar.gz"
 
   head "https://github.com/bedops/bedops.git"
+  sha256 "8364b319831936951835369ef582ac7ddbd15c29682ae0e45a80c4e6a8f36245"
 
   bottle do
     cellar :any

--- a/bedops.rb
+++ b/bedops.rb
@@ -4,7 +4,6 @@ class Bedops < Formula
   # tag "bioinformatics"
 
   url "https://github.com/bedops/bedops/archive/v2.4.15.tar.gz"
-  sha1 "46ff119375dbc3b054c6d6fe35a03cc905e9163e"
 
   head "https://github.com/bedops/bedops.git"
 

--- a/bedops.rb
+++ b/bedops.rb
@@ -3,16 +3,13 @@ class Bedops < Formula
   # doi "10.1093/bioinformatics/bts277"
   # tag "bioinformatics"
 
-  url "https://github.com/bedops/bedops/archive/v2.4.14.tar.gz"
-  sha256 "1b04f8b0551c5f682aabd68ee6f49533be598f4d7e7a1690aad8f3430a530bcf"
+  url "https://github.com/bedops/bedops/archive/v2.4.15.tar.gz"
+  sha1 "46ff119375dbc3b054c6d6fe35a03cc905e9163e"
 
   head "https://github.com/bedops/bedops.git"
 
   bottle do
     cellar :any
-    sha256 "ac1a745078141fc3c14950ba1bd27b15cc886ac5290942f03572d8f76b127a8a" => :yosemite
-    sha256 "24f16e72a7f1401a67e50c851bcc02ea1d694fc08092331ebc611010acc24085" => :mavericks
-    sha256 "c4c3d988b952f794b2bd41c7d9be8ec13ea27549c26d60a50611ed97ad0825bb" => :mountain_lion
   end
 
   env :std


### PR DESCRIPTION
* Added Dockerfiles for CentOS 7 container and RPM creation
* Fixed potential buffer overflows in `convert2bed` for VCF conversion
* General improvements to OS X 10.11 build