### PR TITLE
VTK: 7.0

### DIFF
--- a/vtk.rb
+++ b/vtk.rb
@@ -1,10 +1,10 @@
 class Vtk < Formula
   homepage "http://www.vtk.org"
-  url "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz"
-  mirror "https://fossies.org/linux/misc/VTK-6.3.0.tar.gz"
-  sha256 "92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e"
+  url "http://www.vtk.org/files/release/7.0/VTK-7.0.0.tar.gz"
+  mirror "https://fossies.org/linux/misc/VTK-7.0.0.tar.gz"
+  sha256 "78a990a15ead79cdc752e86b83cfab7dbf5b7ef51ba409db02570dbdd9ec32c3"
+
   head "https://github.com/Kitware/VTK.git"
-  revision 1
 
   bottle do
     sha256 "7e2ded78d69e2cb86e30f2cece78ab66acf553970676251e3d32685fdf7c7443" => :el_capitan

--- a/vtk.rb
+++ b/vtk.rb
@@ -54,11 +54,11 @@ class Vtk < Formula
 
   if build.with? "python3"
     if build.with? "qt"
-      depends_on "sip"
-      depends_on "pyqt" => ["with-python3"]
+      depends_on "sip" => ["with-python3", "without-python"]
+      depends_on "pyqt" => ["with-python3", "without-python" ]
     elsif build.with? "qt5"
-      depends_on "sip"
-      depends_on "pyqt5" => ["with-python3"]
+      depends_on "sip"   => ["with-python3", "without-python"]
+      depends_on "pyqt5"
     end
   end
 
@@ -125,9 +125,10 @@ class Vtk < Formula
         # Set the prefix for the python bindings to the Cellar
         args << "-DVTK_INSTALL_PYTHON_MODULE_DIR='#{lib}/python2.7/site-packages'"
 
-        if build.with? "qt"
+        if build.with?("qt") || build.with?("qt5")
           args << "-DVTK_WRAP_PYTHON_SIP=ON"
-          args << "-DSIP_PYQT_DIR='#{Formula["pyqt"].opt_share}/sip'"
+          args << "-DSIP_PYQT_DIR='#{Formula["pyqt"].opt_share}/sip'" if build.with? "qt"
+          args << "-DSIP_PYQT_DIR='#{Formula["pyqt5"].opt_share}/sip'" if build.with? "qt5"
         end
       elsif build.without?("python") && build.with?("python3")
         args << "-DVTK_WRAP_PYTHON=ON"
@@ -138,9 +139,10 @@ class Vtk < Formula
         # Set the prefix for the python bindings to the Cellar
         args << "-DVTK_INSTALL_PYTHON_MODULE_DIR='#{lib}/python3.5/site-packages'"
 
-        if build.with? "qt"
+        if build.with?("qt") || build.with?("qt5")
           args << "-DVTK_WRAP_PYTHON_SIP=ON"
-          args << "-DSIP_PYQT_DIR='#{Formula["pyqt"].opt_share}/sip'"
+          args << "-DSIP_PYQT_DIR='#{Formula["pyqt"].opt_share}/sip'" if build.with? "qt"
+          args << "-DSIP_PYQT_DIR='#{Formula["pyqt5"].opt_share}/sip'" if build.with? "qt5"
         end
       elsif build.with?("python3") && build.with?("python")
         # Does not currenly support building both python 2 and 3 versions


### PR DESCRIPTION
Upgrade VTK to 7.0 and add support for installing python3 binding. As far as I can tell there is no easy way to build both python 2 and 3 bindings so these are mutually exclusive at this stage. 

Im not sure is other formulas should be have a revision bump to build against this?

Brew audit complains that 

```
homebrew/science/vtk:
 * python modules have explicit framework links
These python extension modules were linked directly to a Python
framework binary. They should be linked with -undefined dynamic_lookup
instead of -lpython or -framework Python.
```

But that is nothing new as far as I can see: