### PR TITLE
pfile-utils (new formula)

### DIFF
--- a/pfile-utils.rb
+++ b/pfile-utils.rb
@@ -1,0 +1,31 @@
+class PfileUtils < Formula
+  desc "Collection of utilities for manipulating PFiles (ICSI feature file)"
+  homepage "http://www1.icsi.berkeley.edu/Speech/qn.html"
+
+  url "https://github.com/Marvin182/pfile-utilities/archive/v0.51.tar.gz"
+  sha256 "151bb83af1c06a7168908d8440ebb15f880de360d7f292f41716fa84b520301a"
+  head "https://github.com/Marvin182/pfile-utilities.git"
+
+  depends_on "quicknet"
+  depends_on "pkg-config" => :build
+
+  def install
+    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    # Create a simple pfile
+    (testpath/"data.txt").write <<-EOS.undent
+      0 0 0 0 0
+      0 1 0 1 1
+      0 2 1 0 1
+      0 3 1 1 0
+    EOS
+    system "#{bin}/pfile_create", "-f", "2", "-l", "1", "-i", "data.txt", "-o", testpath/"data.pfile"
+    # Check if it worked
+    assert_equal "data.pfile\n1 sentences, 4 frames, 1 label(s), 2 features\n", `pfile_info data.pfile`
+    assert_equal "Processing sentence 0\n0 0 0 0 0\n0 1 0 1 1\n0 2 1 0 1\n0 3 1 1 0\n", `pfile_print -i data.pfile`
+  end
+end

--- a/quicknet.rb
+++ b/quicknet.rb
@@ -1,0 +1,31 @@
+class Quicknet < Formula
+  desc "Software suite for multi-layer perceptrons, designed for ASR."
+  homepage "http://www1.icsi.berkeley.edu/Speech/qn.html"
+  url "ftp://ftp.icsi.berkeley.edu/pub/real/davidj/quicknet.tar.gz"
+  version "3.33"
+  sha256 "035003767e1d7580ae30bdf3c4ff839a9b380e239d4b2ecde85df55d94f9a145"
+
+  patch do
+    # patch Makefile.in to make mandir configurable, so we can adjust it to the homebrew standards using configure later
+    # review patch here: https://gist.github.com/Marvin182/41492c9d1992052fa35d
+    url "https://gist.githubusercontent.com/Marvin182/41492c9d1992052fa35d/raw/7e8f3e4102f7cbb2408cf7bf07b2f01f6f1edcb3/patch_quicknet_mandir.diff"
+    sha256 "ebe0f7c57b549fcdef5a2945f50e2dc1145a966113ec6138d8f7ab139ec0b459"
+  end
+
+  def install
+    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert File.exist? "#{bin}/qncopy"
+    assert File.exist? "#{bin}/qncopywts"
+    assert File.exist? "#{bin}/qndo"
+    assert File.exist? "#{bin}/qnmultifwd"
+    assert File.exist? "#{bin}/qnmultitrn"
+    assert File.exist? "#{bin}/qnnorm"
+    assert File.exist? "#{bin}/qnsfwd"
+    assert File.exist? "#{lib}/libquicknet3.dylib"
+  end
+end


### PR DESCRIPTION
pfile-utils is a a collection of utilities for manipulating PFiles, the ICSI feature file archive format. It was invented to store training data for speech recognition system and neural networks and is still used by several research teams in the field.

quicknet is a software suite for training simple neural networks and required by pfile-utils.

Also see original pull request: https://github.com/Homebrew/homebrew/pull/47975