### PR TITLE
Openfst 1.5.1 thrax 1.2.1 ngram 1.2.2

### DIFF
--- a/openfst.rb
+++ b/openfst.rb
@@ -1,7 +1,7 @@
 class Openfst < Formula
   homepage "http://www.openfst.org/"
-  url "http://openfst.org/twiki/pub/FST/FstDownload/openfst-1.5.0.tar.gz"
-  sha256 "01c2b810295a942fede5b711bd04bdc9677855c846fedcc999c792604e02177b"
+  url "http://openfst.org/twiki/pub/FST/FstDownload/openfst-1.5.1.tar.gz"
+  sha256 "d40724bc5641091063db632392e6561e9077d5e0d88ac106d5b30d8f1bcd9925"
 
   bottle do
     cellar :any

--- a/opengrm-ngram.rb
+++ b/opengrm-ngram.rb
@@ -1,7 +1,7 @@
 class OpengrmNgram < Formula
   homepage "http://www.openfst.org/twiki/bin/view/GRM/NGramLibrary"
-  url "http://openfst.cs.nyu.edu/twiki/pub/GRM/NGramDownload/opengrm-ngram-1.2.1.tar.gz"
-  sha256 "713f07dccf225cde29cb048ce955d45d3c2a5ce6be7d923b5a688012d4285453"
+  url "http://openfst.cs.nyu.edu/twiki/pub/GRM/NGramDownload/opengrm-ngram-1.2.2.tar.gz"
+  sha256 "12bba4c1345f3933e161859cc9cb5d21b772d2b46173b4511fc778c67ada233b"
 
   depends_on "openfst"
 

--- a/opengrm-thrax.rb
+++ b/opengrm-thrax.rb
@@ -1,7 +1,7 @@
 class OpengrmThrax < Formula
   homepage "http://www.openfst.org/twiki/bin/view/GRM/Thrax"
-  url "http://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.2.0.tar.gz"
-  sha256 "23112837b64634685e34681758b42b55d09b97b999c2f8a43c0002b870f98fc9"
+  url "http://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.2.1.tar.gz"
+  sha256 "2aaf9bcabe7ad2193ba77d048d7e70a434888c0397ed337f1a01bf0f26549656"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Version bumping all three OpenFST-related libraries to support OpenFST release 1.5.1. See PR #3319 for discussion as to why this PR includes multiple libraries.