### PR TITLE
Update Diamond version to 0.7.11

### DIFF
--- a/diamond.rb
+++ b/diamond.rb
@@ -5,11 +5,10 @@ class Diamond < Formula
   # tag "bioinformatics"
 
   url "https://github.com/bbuchfink/diamond/archive/v0.7.11.tar.gz"
-  version "0.7.11"
   sha256 "e486bed71d5ea1f73c6016504cf137b74ff710422bb7f0038e16360bfb00b2f5"
 
   bottle do
-    sha256 "e486bed71d5ea1f73c6016504cf137b74ff710422bb7f0038e16360bfb00b2f5" => :yosemite
+    sha256 "e0eb3edc6f875a6b8e37b2d369b27510ec714faf2e94ff414edb94fbd34a1141" => :yosemite
     sha256 "da0750e96465902fbd7827dc2220c2cb298f71ae488d6175885eb2044e2066ad" => :mavericks
     sha256 "459c5a98274de600b7a270e51a589c21bae1add6384fe76d4a4b5c3d988778cb" => :mountain_lion
   end

--- a/diamond.rb
+++ b/diamond.rb
@@ -4,11 +4,12 @@ class Diamond < Formula
   # doi "10.1038/nmeth.3176"
   # tag "bioinformatics"
 
-  url "https://github.com/bbuchfink/diamond/archive/v0.7.9.tar.gz"
-  sha256 "25dc43e41768f7a41c98b8b1dcf5aa2c51c0eaf62e71bff22ad01c97b663d341"
+  url "https://github.com/bbuchfink/diamond/archive/v0.7.11.tar.gz"
+  version "0.7.11"
+  sha256 "e486bed71d5ea1f73c6016504cf137b74ff710422bb7f0038e16360bfb00b2f5"
 
   bottle do
-    sha256 "e0eb3edc6f875a6b8e37b2d369b27510ec714faf2e94ff414edb94fbd34a1141" => :yosemite
+    sha256 "e486bed71d5ea1f73c6016504cf137b74ff710422bb7f0038e16360bfb00b2f5" => :yosemite
     sha256 "da0750e96465902fbd7827dc2220c2cb298f71ae488d6175885eb2044e2066ad" => :mavericks
     sha256 "459c5a98274de600b7a270e51a589c21bae1add6384fe76d4a4b5c3d988778cb" => :mountain_lion
   end


### PR DESCRIPTION
I updated my local file this way, unlinked 0.7.9, and installed 0.7.11 this way. There are some serious issues with makedb on 0.7.9, namely bbuchfink/diamond#25 , which warrant a upgrade.