### PR TITLE
SuiteSparse 4.5.1

### DIFF
--- a/suite-sparse.rb
+++ b/suite-sparse.rb
@@ -49,7 +49,7 @@ class SuiteSparse < Formula
     # SuiteSparse is shipped with metis-5.1.0 but it can use Homebrew's version by
     # setting MY_METIS_LIB and MY_METIS_INC variables.
     make_args += ["MY_METIS_LIB=-L#{Formula["metis"].opt_lib} -lmetis",
-                  "MY_METIS_INC=#{Formula["metis"].opt_include}"] if build.with? "metis"
+                  "MY_METIS_INC=#{Formula["metis"].opt_include}"]
 
     # Demos failed to compile. Thus only building libraries.
     system "make", "library", *make_args

--- a/suite-sparse.rb
+++ b/suite-sparse.rb
@@ -26,7 +26,7 @@ class SuiteSparse < Formula
 
   def install
     cflags = "#{ENV.cflags}"
-    cflags += "-fopenmp" if build_with? "openmp"
+    cflags += "-fopenmp" if build.with? "openmp"
     cflags += " -I#{Formula["tbb"].opt_include}" if build.with? "tbb"
 
     make_args = ["CFLAGS=#{cflags}",

--- a/suite-sparse.rb
+++ b/suite-sparse.rb
@@ -14,9 +14,9 @@ class SuiteSparse < Formula
   option "with-matlab", "Install Matlab interfaces and tools"
   option "with-matlab-path=", "Path to Matlab executable (default: matlab)"
 
+  depends_on "metis"  # SuiteSparse must be compiled with metis 5.
+                      # It is shipped with metis-5.1.0
   depends_on "cmake" => :build
-  depends_on "metis" => :recommended  # SuiteSparse must be compiled with metis 5.
-                                      # It is shipped with metis-5.1.0
   depends_on "tbb" => :recommended
   depends_on "openblas" => :optional
 

--- a/suite-sparse.rb
+++ b/suite-sparse.rb
@@ -1,9 +1,8 @@
 class SuiteSparse < Formula
   desc "Suite of Sparse Matrix Software"
   homepage "http://faculty.cse.tamu.edu/davis/suitesparse.html"
-  url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz"
-  sha256 "f2ae47e96f3f37b313c3dfafca59f13e6dbc1e9e54b35af591551919810fb6fd"
-  revision 2
+  url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.5.1.tar.gz"
+  sha256 "ac4524b9f69c4f8c2652d720b146c92a414c1943f86d46df49b4ff8377ae8752"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,22 +14,15 @@ class SuiteSparse < Formula
   option "with-matlab", "Install Matlab interfaces and tools"
   option "with-matlab-path=", "Path to Matlab executable (default: matlab)"
 
+  depends_on "cmake" => :build
+  depends_on "metis" => :recommended  # SuiteSparse must be compiled with metis 5.
+                                      # It is shipped with metis-5.1.0
   depends_on "tbb" => :recommended
   depends_on "openblas" => :optional
-  depends_on "metis4" => :optional # metis 5.x is not yet supported by suite-sparse
 
   depends_on :fortran if build.with? "matlab"
 
   def install
-    # SuiteSparse doesn't like to build in parallel
-    ENV.deparallelize
-
-    # Switch to the Mac base config, per SuiteSparse README.txt
-    mv "SuiteSparse_config/SuiteSparse_config.mk",
-       "SuiteSparse_config/SuiteSparse_config_orig.mk"
-    mv "SuiteSparse_config/SuiteSparse_config_Mac.mk",
-       "SuiteSparse_config/SuiteSparse_config.mk"
-
     cflags = "#{ENV.cflags}"
     cflags += (ENV.compiler == :clang) ? "" : " -fopenmp"
     cflags += " -I#{Formula["tbb"].opt_include}" if build.with? "tbb"
@@ -52,27 +44,16 @@ class SuiteSparse < Formula
     make_args += ["SPQR_CONFIG=-DHAVE_TBB",
                   "TBB=-L#{Formula["tbb"].opt_lib} -ltbb"] if build.with? "tbb"
 
-    # SuiteSparse wants the user to download the source of METIS so it can
-    # compile it. Its way of deciding that METIS has indeed been downloaded is
-    # by checking that METIS_PATH is a valid path. So we specify some valid
-    # path.
-    make_args += ["METIS_PATH=#{Formula["metis4"].opt_prefix}",
-                  "METIS=-L#{Formula["metis4"].opt_lib} -lmetis"] if build.with? "metis4"
-    make_args << "CHOLMOD_CONFIG=-DNPARTITION" if build.without? "metis4"
+    # SuiteSparse is shipped with metis-5.1.0 but it can use Homebrew's version by
+    # setting MY_METIS_LIB and MY_METIS_INC variables.
+    make_args += ["MY_METIS_LIB=-L#{Formula["metis"].opt_lib} -lmetis",
+                  "MY_METIS_INC=#{Formula["metis"].opt_include}"] if build.with? "metis"
 
-    # Add some flags for linux
-    # -DNTIMER is needed to avoid undefined reference to SuiteSparse_time
-    make_args << "CF=-fPIC -O3 -fno-common -fexceptions -DNTIMER $(CFLAGS)" unless OS.mac?
-
-    # make library doesn't build the demos because the latter expect the source
-    # of METIS to have been downloaded and will attempt to build it.
+    # Demos failed to compile. Thus only building libraries.
     system "make", "library", *make_args
     lib.mkpath
     include.mkpath
-    system "make", "install", *make_args
-    ["AMD", "CAMD", "CHOLMOD", "KLU", "LDL", "SPQR", "UMFPACK"].each do |pkg|
-      (doc/pkg).install Dir["#{pkg}/Doc/*"]
-    end
+    system "make", "install",  *make_args
 
     if build.with? "matlab"
       matlab = ARGV.value("with-matlab-path") || "matlab"
@@ -98,7 +79,7 @@ class SuiteSparse < Formula
       s += <<-EOS.undent
         Matlab interfaces and tools have been installed to
 
-          #{share}/suite-sparse/matlab
+          #{pkgshare}/matlab
 
         It is possible that the SPQR interface fail to compile
         if you use the defaults mexopts.sh or if your mexopts.sh

--- a/suite-sparse.rb
+++ b/suite-sparse.rb
@@ -13,6 +13,7 @@ class SuiteSparse < Formula
 
   option "with-matlab", "Install Matlab interfaces and tools"
   option "with-matlab-path=", "Path to Matlab executable (default: matlab)"
+  option "with-openmp", "Build with OpenMP support"
 
   depends_on "metis"  # SuiteSparse must be compiled with metis 5.
                       # It is shipped with metis-5.1.0
@@ -21,10 +22,11 @@ class SuiteSparse < Formula
   depends_on "openblas" => :optional
 
   depends_on :fortran if build.with? "matlab"
+  needs :openmp if build.with? "openmp"
 
   def install
     cflags = "#{ENV.cflags}"
-    cflags += (ENV.compiler == :clang) ? "" : " -fopenmp"
+    cflags += "-fopenmp" if build_with? "openmp"
     cflags += " -I#{Formula["tbb"].opt_include}" if build.with? "tbb"
 
     make_args = ["CFLAGS=#{cflags}",


### PR DESCRIPTION
New version of SuiteSparse. Now builds shared library!!!

SuiteSparse is shipped with metis-5.1.0 and uses it by default. Setting some environment variables make possible the use of Homebrew's version of metis.

Wasn't tested with flag --with-matlab. No Matlab at home.