### PR TITLE
Build ROOT 6 with CMake

### DIFF
--- a/root6.rb
+++ b/root6.rb
@@ -62,7 +62,7 @@ class Root6 < Formula
     # ROOT forbids running CMake in the root of the source directory,
     # so run in a subdirectory (there's already one called `build`)
     mkdir "build_dir" do
-      system "cmake", "..", *std_cmake_args, *args
+      system "cmake", "..", *(std_cmake_args + args)
       system "make", "install"
     end
 

--- a/root6.rb
+++ b/root6.rb
@@ -2,11 +2,12 @@ class Root6 < Formula
   # in order to update, simply change version number and update sha256
   version_number = "6.06.02"
   desc "Object oriented framework for large scale data analysis"
-  homepage "http://root.cern.ch"
+  homepage "https://root.cern.ch"
   url "https://root.cern.ch/download/root_v#{version_number}.source.tar.gz"
   mirror "https://fossies.org/linux/misc/root_v#{version_number}.source.tar.gz"
   version version_number
   sha256 "18a4ce42ee19e1a810d5351f74ec9550e6e422b13b5c58e0c3db740cdbc569d1"
+  revision 1
   head "http://root.cern.ch/git/root.git"
 
   bottle do
@@ -15,6 +16,7 @@ class Root6 < Formula
     sha256 "01b35ce68155fc331a0145a009416f07dbfcee9391d5a5d4d0e88ed890951d20" => :mavericks
   end
 
+  depends_on "cmake" => :build
   depends_on "xrootd" => :optional
   depends_on "openssl" => :recommended # use homebrew's openssl
   depends_on :python => :recommended # make sure we install pyroot
@@ -26,7 +28,7 @@ class Root6 < Formula
   needs :cxx11
 
   def config_opt(opt, pkg = opt)
-    "--#{(build.with? pkg) ? "enable" : "disable"}-#{opt}"
+    "-D#{opt}=#{(build.with? pkg) ? "ON" : "OFF"}"
   end
 
   def install
@@ -38,22 +40,31 @@ class Root6 < Formula
                   "man/man1/setup-pq2.1", "README/INSTALL", "README/README"],
       /bin.thisroot/, "libexec/thisroot"
 
+    # ROOT does the following things by default that `brew audit` doesn't like:
+    #  1. Installs libraries to lib/
+    #  2. Installs documentation to man/
+    # Homebrew expects:
+    #  1. Libraries in lib/<some_folder>
+    #  2. Documentation in share/man
+    # so we set some flags to match what Homebrew expects
     args = %W[
-      --prefix=#{prefix}
-      --elispdir=#{share}/emacs/site-lisp/#{name}
-      --enable-builtin-freetype
-      --enable-roofit
-      --enable-minuit2
+      -Dgnuinstall=ON
+      -DCMAKE_INSTALL_ELISPDIR=#{share}/emacs/site-lisp/#{name}
+      -Dbuiltin_freetype=ON
+      -Droofit=ON
+      -Dminuit2=ON
       #{config_opt("python")}
       #{config_opt("ssl", "openssl")}
       #{config_opt("xrootd")}
       #{config_opt("mathmore", "gsl")}
     ]
 
-    system "./configure", "--help"
-    system "./configure", *args
-    system "make"
-    system "make", "install"
+    # ROOT forbids running CMake in the root of the source directory,
+    # so run in a subdirectory (there's already one called `build`)
+    mkdir "build_dir" do
+      system "cmake", "..", *std_cmake_args, *args
+      system "make", "install"
+    end
 
     libexec.mkpath
     mv Dir["#{bin}/*.*sh"], libexec


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

---

This PR changes the way ROOT is built, from the old `configure && make install` style to `cmake && make install`.

There are a couple of reasons for doing this. Firstly, to quote [the ROOT developers](https://root.cern.ch/building-root):

> The classic build with configure/make is is still available but it will not be evolving with the new features of ROOT.

Secondly, I've come across, and heard other people talk about, problems that only appear in the `configure` build (the current Homebrew method). I guess this is because the ROOT developers are focusing on the CMake build nows, so they don't notice changes that break functionality with `configure` builds and/or they have `configure`-related bug reports as a low priority.

Switching to a CMake-based build seems like The Right Thing.

We could also address #1915 in this PR by using `-Dall=ON`, rather than specifying a few particular flags [as is done now](https://github.com/Homebrew/homebrew-science/compare/master...alexpearce:root6-cmake?expand=1#diff-b316bc9bd3af2682b35a6b917a29b62dR54). I have no preference, the ROOT build this PR gives me is suitable for my needs.