### PR TITLE
qualimap 28-03-16

### DIFF
--- a/qualimap.rb
+++ b/qualimap.rb
@@ -1,8 +1,9 @@
 class Qualimap < Formula
+  desc "Facilitates the quality control of alignment sequencing data"
   homepage "http://qualimap.bioinfo.cipf.es/"
   url "https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-28-03-16.tar.gz"
-  sha256 "12fd342a2ccc76ea09bbd5e9ae38c1ae9ae44aad5e6f0296298e584e55b0d8ae"
   version "20160328"
+  sha256 "12fd342a2ccc76ea09bbd5e9ae38c1ae9ae44aad5e6f0296298e584e55b0d8ae"
   bottle do
     cellar :any
     sha256 "312dbd9f9a0537ef4ab379d5d65d905455e7f01af827de75643d89beb0e305b0" => :yosemite

--- a/qualimap.rb
+++ b/qualimap.rb
@@ -1,8 +1,8 @@
 class Qualimap < Formula
   homepage "http://qualimap.bioinfo.cipf.es/"
-  url "https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-31-08-15.tar.gz"
-  sha256 "30a721b931b8e5b9304089edadbb15718bb9f2bfae70568836595196b4dd523e"
-  version "20150831"
+  url "https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-28-03-16.tar.gz"
+  sha256 "12fd342a2ccc76ea09bbd5e9ae38c1ae9ae44aad5e6f0296298e584e55b0d8ae"
+  version "20160328"
   bottle do
     cellar :any
     sha256 "312dbd9f9a0537ef4ab379d5d65d905455e7f01af827de75643d89beb0e305b0" => :yosemite


### PR DESCRIPTION
Upgrade to qualimap 28-03-16 (the [most recent](https://bitbucket.org/kokonech/qualimap/downloads)), thus fixing this error:
``Installing qualimap from homebrew/science
Downloading https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build
curl: (22) The requested URL returned error: 404 NOT FOUND
Error: Failed to download resource "qualimap"
Download failed: https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-31-08-15.tar.gz
``

Apparently, a [BitBucket server error occurred](https://bitbucket.org/kokonech/qualimap/issues/38/empty-files-in-downloads), making version 31-08-15 no longer available. 

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

