### PR TITLE
SPAdes: SPAdes 3.7.1

### DIFF
--- a/spades.rb
+++ b/spades.rb
@@ -3,8 +3,8 @@ class Spades < Formula
   homepage "http://bioinf.spbau.ru/spades/"
   # tag "bioinformatics"
   # doi "10.1089/cmb.2012.0021"
-  url "http://spades.bioinf.spbau.ru/release3.7.0/SPAdes-3.7.0.tar.gz"
-  sha256 "4d9b114150c4d37084967a5a3264d36a480394996197949fb72402f2d65b42a3"
+  url "http://spades.bioinf.spbau.ru/release3.7.1/SPAdes-3.7.1.tar.gz"
+  sha256 "e904f57b08c5790c64406763b29650ffba872da47ec5a3e659396fcfcbc9b35a"
 
   bottle do
     cellar :any
@@ -28,7 +28,7 @@ class Spades < Formula
       system "make", "install"
     end
 
-    # Fix the audit error "Non-executables were installed to bin"
+    # Fix audit error "Non-executables were installed to bin"
     inreplace bin/"spades_init.py" do |s|
       s.sub! /^/, "#!/usr/bin/env python\n"
     end


### PR DESCRIPTION
Fixes showstopper bug in mismatch corrector under OS X introduced in 3.7.0

-------------------

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Built your formula locally prior to submission with `brew install <formula>`?
- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?  
  
**Any suggestions for dealing with the below?:**
```
homebrew/science/spades:
 * Non-executables were installed to "/usr/local/Cellar/spades/3.7.1/bin"
The offending files are:
  /usr/local/Cellar/spades/3.7.1/bin/__pycache__
  /usr/local/Cellar/spades/3.7.1/bin/spades_init.pyc
```
