### PR TITLE
pcl depends on Vtk6, adding version for vtk6

### DIFF
--- a/pcl.rb
+++ b/pcl.rb
@@ -84,13 +84,13 @@ class Pcl < Formula
   if build.with? "qt"
     depends_on "sip" # Fix for building system
     depends_on "pyqt" # Fix for building system
-    depends_on "vtk" => [:recommended, "with-qt"]
+    depends_on "vtk6" => [:recommended, "with-qt"]
   elsif build.with? "qt5"
     depends_on "sip" # Fix for building system
     depends_on "pyqt5" => ["with-python", "without-python3"] # Fix for building system
-    depends_on "vtk" => [:recommended, "with-qt5"]
+    depends_on "vtk6" => [:recommended, "with-qt5"]
   else
-    depends_on "vtk" => :recommended
+    depends_on "vtk6" => :recommended
   end
   depends_on "openni" => :optional
   depends_on "openni2" => :optional

--- a/vtk6.rb
+++ b/vtk6.rb
@@ -1,9 +1,9 @@
 class Vtk6 < Formula
+  desc "Visualization Toolkit (VTK) for 3D computer graphics, image processing, and visualization."
   homepage "http://www.vtk.org"
   url "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz"
   mirror "https://fossies.org/linux/misc/VTK-6.3.0.tar.gz"
   sha256 "92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e"
-  revision 1
   head "https://github.com/Kitware/VTK.git"
 
   bottle do

--- a/vtk6.rb
+++ b/vtk6.rb
@@ -3,8 +3,8 @@ class Vtk6 < Formula
   url "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz"
   mirror "https://fossies.org/linux/misc/VTK-6.3.0.tar.gz"
   sha256 "92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e"
-  head "https://github.com/Kitware/VTK.git"
   revision 1
+  head "https://github.com/Kitware/VTK.git"
 
   bottle do
     sha256 "7e2ded78d69e2cb86e30f2cece78ab66acf553970676251e3d32685fdf7c7443" => :el_capitan

--- a/vtk6.rb
+++ b/vtk6.rb
@@ -1,0 +1,150 @@
+class Vtk < Formula
+  homepage "http://www.vtk.org"
+  url "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz"
+  mirror "https://fossies.org/linux/misc/VTK-6.3.0.tar.gz"
+  sha256 "92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e"
+  head "https://github.com/Kitware/VTK.git"
+  revision 1
+
+  bottle do
+    sha256 "7e2ded78d69e2cb86e30f2cece78ab66acf553970676251e3d32685fdf7c7443" => :el_capitan
+    sha256 "bbe389a1f316d5f43b5310e1dcd297b686dcae5aa58c07eceaf839b776e3d2fe" => :yosemite
+    sha256 "3efa044d6f708e6480fd30878603ae1738bf11ae527ff08412ba18c0384e4047" => :mavericks
+  end
+
+  deprecated_option "examples" => "with-examples"
+  deprecated_option "qt-extern" => "with-qt-extern"
+  deprecated_option "tcl" => "with-tcl"
+  deprecated_option "remove-legacy" => "without-legacy"
+
+  option :cxx11
+  option "with-examples",   "Compile and install various examples"
+  option "with-qt-extern",  "Enable Qt4 extension via non-Homebrew external Qt4"
+  option "with-tcl",        "Enable Tcl wrapping of VTK classes"
+  option "with-matplotlib", "Enable matplotlib support"
+  option "without-legacy",  "Disable legacy APIs"
+  option "without-python",  "Build without python2 support"
+
+  depends_on "cmake" => :build
+  depends_on :x11 => :optional
+  depends_on "qt" => :optional
+  depends_on "qt5" => :optional
+
+  depends_on :python => :recommended if MacOS.version <= :snow_leopard
+
+  depends_on "boost" => :recommended
+  depends_on "fontconfig" => :recommended
+  depends_on "hdf5" => :recommended
+  depends_on "jpeg" => :recommended
+  depends_on "libpng" => :recommended
+  depends_on "libtiff" => :recommended
+  depends_on "matplotlib" => :python if build.with?("matplotlib") && build.with?("python")
+
+  # If --with-qt and --with-python, then we automatically use PyQt, too!
+  if build.with? "python"
+    if build.with? "qt"
+      depends_on "sip"
+      depends_on "pyqt"
+    elsif build.with? "qt5"
+      depends_on "sip"
+      depends_on "pyqt5" => ["with-python", "without-python3"]
+    end
+  end
+
+  def install
+    args = std_cmake_args + %W[
+      -DVTK_REQUIRED_OBJCXX_FLAGS=''
+      -DVTK_USE_CARBON=OFF
+      -DVTK_USE_TK=OFF
+      -DBUILD_SHARED_LIBS=ON
+      -DIOKit:FILEPATH=#{MacOS.sdk_path}/System/Library/Frameworks/IOKit.framework
+      -DCMAKE_INSTALL_RPATH:STRING=#{lib}
+      -DCMAKE_INSTALL_NAME_DIR:STRING=#{lib}
+      -DVTK_USE_SYSTEM_EXPAT=ON
+      -DVTK_USE_SYSTEM_LIBXML2=ON
+      -DVTK_USE_SYSTEM_ZLIB=ON
+    ]
+
+    args << "-DBUILD_EXAMPLES=" + ((build.with? "examples") ? "ON" : "OFF")
+
+    if build.with? "examples"
+      args << "-DBUILD_TESTING=ON"
+    else
+      args << "-DBUILD_TESTING=OFF"
+    end
+
+    if build.with?("qt") || build.with?("qt5") || build.with?("qt-extern")
+      args << "-DVTK_QT_VERSION:STRING=5" if build.with? "qt5"
+      args << "-DVTK_Group_Qt=ON"
+    end
+
+    args << "-DVTK_WRAP_TCL=ON" if build.with? "tcl"
+
+    # Cocoa for everything except x11
+    if build.with? "x11"
+      args << "-DVTK_USE_COCOA=OFF"
+      args << "-DVTK_USE_X=ON"
+    else
+      args << "-DVTK_USE_COCOA=ON"
+    end
+
+    unless MacOS::CLT.installed?
+      # We are facing an Xcode-only installation, and we have to keep
+      # vtk from using its internal Tk headers (that differ from OSX's).
+      args << "-DTK_INCLUDE_PATH:PATH=#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Headers"
+      args << "-DTK_INTERNAL_PATH:PATH=#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Headers/tk-private"
+    end
+
+    args << "-DModule_vtkInfovisBoost=ON" << "-DModule_vtkInfovisBoostGraphAlgorithms=ON" if build.with? "boost"
+    args << "-DModule_vtkRenderingFreeTypeFontConfig=ON" if build.with? "fontconfig"
+    args << "-DVTK_USE_SYSTEM_HDF5=ON" if build.with? "hdf5"
+    args << "-DVTK_USE_SYSTEM_JPEG=ON" if build.with? "jpeg"
+    args << "-DVTK_USE_SYSTEM_PNG=ON" if build.with? "libpng"
+    args << "-DVTK_USE_SYSTEM_TIFF=ON" if build.with? "libtiff"
+    args << "-DModule_vtkRenderingMatplotlib=ON" if build.with? "matplotlib"
+    args << "-DVTK_LEGACY_REMOVE=ON" if build.without? "legacy"
+
+    ENV.cxx11 if build.cxx11?
+
+    mkdir "build" do
+      if build.with? "python"
+        args << "-DVTK_WRAP_PYTHON=ON"
+        # CMake picks up the system"s python dylib, even if we have a brewed one.
+        args << "-DPYTHON_LIBRARY='#{`python-config --prefix`.chomp}/lib/libpython2.7.dylib'"
+        # Set the prefix for the python bindings to the Cellar
+        args << "-DVTK_INSTALL_PYTHON_MODULE_DIR='#{lib}/python2.7/site-packages'"
+
+        if build.with? "qt"
+          args << "-DVTK_WRAP_PYTHON_SIP=ON"
+          args << "-DSIP_PYQT_DIR='#{Formula["pyqt"].opt_share}/sip'"
+        end
+      end
+      args << ".."
+      system "cmake", *args
+      system "make"
+      system "make", "install"
+    end
+
+    (share+"vtk").install "Examples" if build.with? "examples"
+  end
+
+  def caveats
+    s = ""
+    s += <<-EOS.undent
+        Even without the --with-qt option, you can display native VTK render windows
+        from python. Alternatively, you can integrate the RenderWindowInteractor
+        in PyQt, PySide, Tk or Wx at runtime. Read more:
+            import vtk.qt4; help(vtk.qt4) or import vtk.wx; help(vtk.wx)
+
+    EOS
+
+    if build.with? "examples"
+      s += <<-EOS.undent
+
+        The scripting examples are stored in #{HOMEBREW_PREFIX}/share/vtk
+
+      EOS
+    end
+    s.empty? ? nil : s
+  end
+end

--- a/vtk6.rb
+++ b/vtk6.rb
@@ -1,4 +1,4 @@
-class Vtk < Formula
+class Vtk6 < Formula
   homepage "http://www.vtk.org"
   url "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz"
   mirror "https://fossies.org/linux/misc/VTK-6.3.0.tar.gz"


### PR DESCRIPTION
Per these issues:
https://github.com/Homebrew/homebrew-science/issues/3370
https://github.com/mikepurvis/ros-install-osx/issues/32 (external)

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
