### PR TITLE
Updated gdcm to 2.6.3 and added patches to compile with vtk6 and 7

### DIFF
--- a/gdcm.rb
+++ b/gdcm.rb
@@ -1,13 +1,43 @@
 class Gdcm < Formula
   desc "Grassroots DICOM library and utilities for medical files"
   homepage "http://sourceforge.net/projects/gdcm/"
-  url "https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.6.1/gdcm-2.6.1.tar.bz2"
-  sha256 "db12ac4322448dbf707e58d76fa0dc1232ed229d46391236a042588cf50b8033"
+  url "http://heanet.dl.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.6.3/gdcm-2.6.3.tar.bz2"
+  sha256 "7882e880b8b60efc66a492ae3c1c161799340ad62a90d690823b76eb400c0a8f"
 
   bottle do
     sha256 "5e480698f28f6a3d7e16eeec541feb9b6e0ec24edfe4f3c5c35c11f80895d28d" => :el_capitan
     sha256 "1d046333077cc1f5325247a9f23260cabc1fe6152c75ddd0333e1ad14bcbdf46" => :yosemite
     sha256 "be5cf5f2ffd1d68322a01d22de4f119366fb26cecb9484c801819ec988d804bf" => :mavericks
+  end
+
+  patch do
+      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/01_vtkCxxRevisionMacro.patch"
+      sha256 "4b21c41c562880ae7e31b075f1b945c19d4e5d27442085953f89b2f27cae99e3"
+  end
+
+  patch do
+      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/02_vtkTypeRevisionMacro.patch"
+      sha256 "234d9fb4b33fd55b66f0662bb5ea0347caf7c79868c7171de42fdaab8bbb8389"
+  end
+
+  patch do
+      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/03_float_double.patch"
+      sha256 "9cbe64dd7b518888c1a5c6b3e88f321139806e9078fc9c71abe0ad444008c496"
+  end
+
+  patch do
+      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/ced7783f695a8156d9ed95559d9026d65c63296c/04_vtkfloatingpoint_app.patch"
+      sha256 "a1798438aba1ea0e916aab08436178ebc49b560de373f57eea7c0d1f1184bd17"
+  end
+
+  patch do
+      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/13c5656edd53c364c624e064b110635c47cf4b64/05_vtk7python.patch"
+      sha256 "237aa9bf44157d327c9877cfc57e353919a9d756dd05f52f4ccf6a39ae581af1"
+  end
+
+  patch do
+      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/13c5656edd53c364c624e064b110635c47cf4b64/06_vtk7apps_examples.patches"
+      sha256 "f9184c3f57dbc34179e5bb1a7f1144ffa850f94497add4d782bdffc06577cf8d"
   end
 
   option "with-check", "Run the GDCM test suite"

--- a/gdcm.rb
+++ b/gdcm.rb
@@ -1,7 +1,7 @@
 class Gdcm < Formula
   desc "Grassroots DICOM library and utilities for medical files"
   homepage "http://sourceforge.net/projects/gdcm/"
-  url "http://heanet.dl.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.6.3/gdcm-2.6.3.tar.bz2"
+  url "https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.6.3/gdcm-2.6.3.tar.bz2"
   sha256 "7882e880b8b60efc66a492ae3c1c161799340ad62a90d690823b76eb400c0a8f"
 
   bottle do
@@ -11,33 +11,33 @@ class Gdcm < Formula
   end
 
   patch do
-      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/01_vtkCxxRevisionMacro.patch"
-      sha256 "4b21c41c562880ae7e31b075f1b945c19d4e5d27442085953f89b2f27cae99e3"
+    url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/01_vtkCxxRevisionMacro.patch"
+    sha256 "4b21c41c562880ae7e31b075f1b945c19d4e5d27442085953f89b2f27cae99e3"
   end
 
   patch do
-      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/02_vtkTypeRevisionMacro.patch"
-      sha256 "234d9fb4b33fd55b66f0662bb5ea0347caf7c79868c7171de42fdaab8bbb8389"
+    url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/02_vtkTypeRevisionMacro.patch"
+    sha256 "234d9fb4b33fd55b66f0662bb5ea0347caf7c79868c7171de42fdaab8bbb8389"
   end
 
   patch do
-      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/03_float_double.patch"
-      sha256 "9cbe64dd7b518888c1a5c6b3e88f321139806e9078fc9c71abe0ad444008c496"
+    url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/6e912995d89b65d0cc2cb5d9714dd9450d04a768/03_float_double.patch"
+    sha256 "9cbe64dd7b518888c1a5c6b3e88f321139806e9078fc9c71abe0ad444008c496"
   end
 
   patch do
-      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/ced7783f695a8156d9ed95559d9026d65c63296c/04_vtkfloatingpoint_app.patch"
-      sha256 "a1798438aba1ea0e916aab08436178ebc49b560de373f57eea7c0d1f1184bd17"
+    url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/ced7783f695a8156d9ed95559d9026d65c63296c/04_vtkfloatingpoint_app.patch"
+    sha256 "a1798438aba1ea0e916aab08436178ebc49b560de373f57eea7c0d1f1184bd17"
   end
 
   patch do
-      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/13c5656edd53c364c624e064b110635c47cf4b64/05_vtk7python.patch"
-      sha256 "237aa9bf44157d327c9877cfc57e353919a9d756dd05f52f4ccf6a39ae581af1"
+    url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/13c5656edd53c364c624e064b110635c47cf4b64/05_vtk7python.patch"
+    sha256 "237aa9bf44157d327c9877cfc57e353919a9d756dd05f52f4ccf6a39ae581af1"
   end
 
   patch do
-      url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/13c5656edd53c364c624e064b110635c47cf4b64/06_vtk7apps_examples.patches"
-      sha256 "f9184c3f57dbc34179e5bb1a7f1144ffa850f94497add4d782bdffc06577cf8d"
+    url "https://gist.githubusercontent.com/tfmoraes/5489a2473c1ed6cc296aa646432a8536/raw/13c5656edd53c364c624e064b110635c47cf4b64/06_vtk7apps_examples.patches"
+    sha256 "f9184c3f57dbc34179e5bb1a7f1144ffa850f94497add4d782bdffc06577cf8d"
   end
 
   option "with-check", "Run the GDCM test suite"


### PR DESCRIPTION
This pull request updates the GDCM formula to compile the new GDCM version, 2.6.3. Also, it applies some patches to compile GDCM with VTK6 and 7. I submitted 2 pull requests with those patches to GDCM upstream. The (first one)[https://github.com/malaterre/GDCM/pull/21] is already merged. The (second one)[https://github.com/malaterre/GDCM/pull/22] is waiting to be merged. I only tested it with Python Wrapper, I don' t know if the other Wrappers is working.