### PR TITLE
BEDOPS 2.4.17

### DIFF
--- a/bedops.rb
+++ b/bedops.rb
@@ -1,10 +1,11 @@
 class Bedops < Formula
+  desc "Set and statistical operations on genomic data of arbitrary scale"
   homepage "https://github.com/bedops/bedops"
   # doi "10.1093/bioinformatics/bts277"
   # tag "bioinformatics"
 
-  url "https://github.com/bedops/bedops/archive/v2.4.15.tar.gz"
-  sha256 "8364b319831936951835369ef582ac7ddbd15c29682ae0e45a80c4e6a8f36245"
+  url "https://github.com/bedops/bedops/archive/v2.4.17.tar.gz"
+  sha256 "a7e8b4b811899ac96f962dbe5319af7360bc4ddc75c517b5206021a1c46a05bf"
 
   head "https://github.com/bedops/bedops.git"
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [n/a] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [n/a] Removed the `revision` line, if any, when bumping the version number?
- [n/a] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

----

- `bedmap`

  Added new `--echo-ref-row-id` option to report reference row ID elements.

- `convert2bed`

  Fixed issues with converting some BAM and SAM inputs to BED format.

- Starch C++ API

  Fixed a bug with extraction of archives made with `starch --gzip` and `--bzip2` (thanks to Brad Gulko and Feng Tian).
