### PR TITLE
butterflow: revision for ffmpeg

### DIFF
--- a/butterflow.rb
+++ b/butterflow.rb
@@ -1,9 +1,9 @@
 class Butterflow < Formula
-  desc "Makes fluid slowmo and motion interpolated videos"
+  desc "Makes fluid slow motion and motion interpolated videos"
   homepage "https://github.com/dthpham/butterflow"
   url "http://srv.dthpham.me/butterflow/butterflow-0.2.0.tar.gz"
   sha256 "dc70927d78193543b4b364573e0cf2d0881a54483aa306db51cd9f57cf23781e"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any


### PR DESCRIPTION
Current bottles are linked against
  libavcodec.56.dylib
  libavformat.56.dylib
  libavutil.54.dylib

But the current versions are 57, 57, and 55, respectively.