### PR TITLE
qgis: remove all grass references and dependencies

### DIFF
--- a/qgis.rb
+++ b/qgis.rb
@@ -32,8 +32,6 @@ class Qgis < Formula
   depends_on "proj"
   depends_on "spatialindex"
   depends_on "bison"
-  depends_on "grass" => :optional
-  depends_on "gettext" if build.with? "grass"
   depends_on "postgis" => :optional
 
   def install
@@ -49,11 +47,6 @@ class Qgis < Formula
       -DQGIS_MACAPP_INSTALL_DEV=YES
       -DPYTHON_LIBRARY='#{`python-config --prefix`.chomp}/lib/libpython2.7.dylib'
     ]
-
-    args << "-DGRASS_PREFIX='#{Formula["grass"].opt_prefix}'" if build.with? "grass"
-
-    # So that `libintl.h` can be found
-    ENV.append "CXXFLAGS", "-I'#{Formula["gettext"].opt_prefix}/include'" if build.with? "grass"
 
     # Avoid ld: framework not found QtSql (https://github.com/Homebrew/homebrew-science/issues/23)
     ENV.append "CXXFLAGS", "-F#{Formula["qt"].opt_prefix}/lib"


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?

Complains about `test do` and `desc`... I am not the author, and have no idea what the package does or how to test it.

- [x] Built your formula locally prior to submission with `brew install <formula>`?

Can't due to problems with pyqt/PYTHONPATH

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?

Should not affect bottles

- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

Can't build, so can't test

 grass is (at least temporarily) being boneyarded. See the PR
 Homebrew/homebrew-core#676 for more details.