### PR TITLE
Update root.rb to fix a python bug

### DIFF
--- a/root.rb
+++ b/root.rb
@@ -20,7 +20,7 @@ class Root < Formula
   depends_on "fftw" => :optional
   depends_on "qt" => [:optional, "with-qt3support"]
   depends_on :x11 => :optional
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on :python
 
   def install
     # brew audit doesn't like non-executables in bin


### PR DESCRIPTION
### Have you:

- [ X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ X] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ X] Not altered the `bottle` section?
- [ X] Checked that the tests still pass?

There was an issue when using pyROOT when root tries to link to python that is not Homebrew python (I think...)
A related issue is discussed a bit here: https://root.cern.ch/phpBB3/viewtopic.php?t=17714