### PR TITLE
edirect 2016-06-29

### DIFF
--- a/edirect.rb
+++ b/edirect.rb
@@ -1,10 +1,12 @@
 class Edirect < Formula
+  desc "Advanced method for accessing the NCBI's databases"
   homepage "http://www.ncbi.nlm.nih.gov/books/NBK179288/"
-  # tag "bioinformatics"
+  url "ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/2016-06-28/edirect.tar.gz"
+  version "2016-06-28"
+  sha256 "cb394e73b8370c66b22c48f8725ff5516a41daad7c9f6780c9728cbf8eb69030"
+  head "ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/current/edirect.tar.gz"
 
-  url "ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/edirect.tar.gz"
-  sha256 "2d108d780cef39bc4fdfd265d97ebaafe59ec937667061f54274f17a40a1a74f"
-  version "3.60"
+  # tag "bioinformatics"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,13 +15,15 @@ class Edirect < Formula
     sha256 "205623c6f64a0c761a10c825249a9a0db6627d5bd6f8c6b7cfc2f822bfa8c81a" => :mavericks
   end
 
+  depends_on "go" => :run
+
   def install
-    doc.install "README"
-    libexec.install "setup.sh", "setup-deps.pl"
-    bin.install Dir["*"]
+    system "go", "build"
+    libexec.install %w[setup.sh setup-deps.pl Mozilla-CA.tar.gz xtract.go]
+    bin.install Dir["*"].select { |f| File.executable?(f) }
   end
 
   test do
-    system "#{bin}/esearch", "-version"
+    system bin/"esearch", "-help"
   end
 end


### PR DESCRIPTION
- use versioned URLs for the stable spec
- add a head spec using the URL pointing of the "current" version
- fix audit issue about non-binaries in bin