### PR TITLE
openni: Fix compilation of HEAD

### DIFF
--- a/openni.rb
+++ b/openni.rb
@@ -1,8 +1,6 @@
 class Openni < Formula
   homepage "http://www.openni.org/"
 
-  head "https://github.com/OpenNI/OpenNI.git"
-
   stable do
     url "https://github.com/OpenNI/OpenNI/archive/Stable-1.5.7.10.tar.gz"
     sha256 "34b0bbf68633bb213dcb15408f979d5384bdceb04e151fa519e107a12e225852"
@@ -22,6 +20,14 @@ class Openni < Formula
     patch do
       url "https://github.com/OpenNI/OpenNI/pull/95.diff"
       sha256 "722fb0a6e6e99a5cc7c7e862ac802dfd3d03785c27af1d20d7f48314ff5154dd"
+    end
+  end
+
+  head do
+    url "https://github.com/OpenNI/OpenNI.git"
+    patch do
+      url "https://github.com/OpenNI/OpenNI/pull/106.diff"
+      sha256 "4aa53e8d6447417be32d1d7ff93788838ee837de291620cb753395be57a25d1d"
     end
   end
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

There are `brew audit` errors that existed before this modification (lack of `desc` and tests) but they're beyond the scope of this fix.


### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

This fixes the compilation of the HEAD version of OpenNI.  The issue and fix are described in OpenNI/OpenNI#106
