### PR TITLE
tophat: fixes for python and script paths

### DIFF
--- a/tophat.rb
+++ b/tophat.rb
@@ -3,9 +3,9 @@ class Tophat < Formula
   homepage "http://ccb.jhu.edu/software/tophat"
   url "http://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.1.tar.gz"
   sha256 "37840b96f3219630082b15642c47f5ef95d14f6ee99c06a369b08b3d05684da5"
+  revision 2
   # doi "10.1093/bioinformatics/btp120"
   # tag "bioinformatics"
-  revision 1
 
   bottle do
     cellar :any
@@ -18,6 +18,7 @@ class Tophat < Formula
   depends_on "boost"
   depends_on "bowtie2"
   depends_on "bowtie" => :optional
+  depends_on :python if MacOS.version <= :snow_leopard
 
   patch :p0, :DATA
 
@@ -63,3 +64,53 @@ __END__
  	{																	\
  		type_t *i, *j, swap_tmp;										\
  		for (i = s + 1; i < t; ++i)										\
+--- src/tophat.py       2016-02-15 11:30:16.619093000 -0800
++++ src/tophat.py       2016-07-17 09:40:08.041311408 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2.7
+
+ # encoding: utf-8
+ """
+--- src/tophat2.sh      2016-02-23 18:51:33.274718000 -0800
++++ src/tophat2.sh        2016-07-17 09:40:56.017800465 -0700
+@@ -1,6 +1,6 @@
+ #!/usr/bin/env bash
+ pbin=""
+-fl=$(readlink $0)
++fl=$(readlink -f $0)
+ if [[ -z "$fl" ]]; then
+    pbin=$(dirname $0)
+  else
+--- src/bed_to_juncs        2016-02-14 10:21:17.133079000 -0800
++++ src/bed_to_juncs  2016-07-17 09:53:12.097361445 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2.7
+ # encoding: utf-8
+ """
+ bed_to_juncs.py
+--- src/contig_to_chr_coords        2016-02-14 10:21:17.199079000 -0800
++++ src/contig_to_chr_coords  2016-07-17 09:53:12.105361528 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2.7
+ # encoding: utf-8
+ """
+ contig_to_chr_coords.py
+--- src/sra_to_solid        2016-02-14 10:21:17.802079000 -0800
++++ src/sra_to_solid  2016-07-17 09:53:12.109361569 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2.7
+
+ """
+ sra_to_solid.py
+--- src/tophat-fusion-post  2016-02-23 13:20:44.317710000 -0800
++++ src/tophat-fusion-post    2016-07-17 09:53:12.113361611 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2.7
+
+
+ """


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

This adds patches to the tophat recipe to make all the python scripts
look for "python2" instead of just "python", since otherwise the tophat
scripts only run under python 2, and will fail if "python" points to
python 3. In addition, the "tophat2" script that just acts as an alias
to "tophat" has been modified to use `readlink -f` instead of just
`readlink`, so it now works when symlinked.