### PR TITLE
Fix to depreciation of MacOS.clang_version

### DIFF
--- a/octave.rb
+++ b/octave.rb
@@ -20,7 +20,7 @@ class Octave < Formula
     end
   end
 
-  if OS.mac? && MacOS.clang_version < "7.0"
+  if OS.mac? && DevelopmentTools.clang_version < "7.0"
     # Fix the build error with LLVM 3.5svn (-3.6svn?) and libc++ (bug #43298)
     # See: http://savannah.gnu.org/bugs/?43298
     patch do


### PR DESCRIPTION
### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

"MacOS.clang_version" has been depreciated in favor of "DevelopmentTools.clang_version".