### PR TITLE
nixio: fix --HEAD build

### DIFF
--- a/nixio.rb
+++ b/nixio.rb
@@ -3,7 +3,7 @@ class Nixio < Formula
   homepage "http://www.g-node.org/nix"
   url "https://github.com/G-Node/nix/archive/1.1.0.tar.gz"
   sha256 "d607d96117621e5cc563002c4c161913d95db36eeb7c4e6f51afca5f6b788fcc"
-  revision 1
+  revision 2
 
   head "https://github.com/G-Node/nix.git"
 
@@ -35,7 +35,7 @@ class Nixio < Formula
     ENV.cxx11
 
     # https://github.com/G-Node/nix/pull/622
-    inreplace "CMakeLists.txt", "(nix CXX)", "(nix C CXX)"
+    inreplace "CMakeLists.txt", "(nix CXX)", "(nix C CXX)" if !build.head?
 
     system "cmake", ".", *std_cmake_args
     system "make"


### PR DESCRIPTION
The fix in pr #3978 lead to head builds being broken:

```sh
==> Checking out branch master
Error: inreplace failed
CMakeLists.txt:
  expected replacement of "(nix CXX)" with "(nix C CXX)"
```

This PR fixes it by only applying the build fix on !head builds.