### PR TITLE
flann 1.9.1

### DIFF
--- a/flann.rb
+++ b/flann.rb
@@ -1,9 +1,8 @@
 class Flann < Formula
-  desc "FLANN - Fast Library for Approximate Nearest Neighbors"
+  desc "Fast Library for Approximate Nearest Neighbors"
   homepage "http://www.cs.ubc.ca/~mariusm/index.php/FLANN/FLANN"
-  url "http://people.cs.ubc.ca/~mariusm/uploads/FLANN/flann-1.8.4-src.zip"
-  sha256 "dfbb9321b0d687626a644c70872a2c540b16200e7f4c7bd72f91ae032f445c08"
-  revision 1
+  url "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz"
+  sha256 "b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3"
 
   bottle do
     cellar :any
@@ -17,6 +16,8 @@ class Flann < Formula
 
   option "with-octave", "Enable Matlab/Octave bindings"
   option "without-examples", "Do not build and install example binaries"
+  option "with-openmp", "Build with OpenMP support"
+  needs :openmp if build.with? "openmp"
 
   depends_on "cmake" => :build
   depends_on "hdf5"

--- a/pcl.rb
+++ b/pcl.rb
@@ -6,7 +6,7 @@ class Pcl < Formula
   url "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.8.0.tar.gz"
   sha256 "9e54b0c1b59a67a386b9b0f4acb2d764272ff9a0377b825c4ed5eedf46ebfcf4"
   head "https://github.com/PointCloudLibrary/pcl.git"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "a63ef4e2a8325e425059963fef8f669fbda997a78eeb7a34777e356a3020a1d3" => :el_capitan


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

I also added a --with-openmp option, and make audit happy by removing the
name from its desc.

audit still shows me a bunch of error messages like:

```
Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Library/Taps/homebrew/homebrew-science/flann.rb:6:in `<class:Flann>'
Please report this to the homebrew/science tap!
```
...but since line 6 is blank, and sha1 isn't used in the file, I don't know what's up with that.