### PR TITLE
mfem 3.2: add superlu_dist option

### DIFF
--- a/mfem.rb
+++ b/mfem.rb
@@ -25,9 +25,15 @@ class Mfem < Formula
     depends_on "metis" => :optional
   end
 
+  if OS.mac?
+    depends_on "openblas" => :optional
+  else
+    depends_on "openblas"
+  end
+
   depends_on "suite-sparse" => :optional
-  depends_on "openblas" => :optional
   depends_on "netcdf" => :optional
+  depends_on "superlu_dist" => :optional
 
   def install
     make_args = ["PREFIX=#{prefix}"]
@@ -63,6 +69,14 @@ class Mfem < Formula
                     "SUITESPARSE_DIR=#{Formula["suite-sparse"].opt_prefix}",
                     "SUITESPARSE_OPT=-I#{Formula["suite-sparse"].opt_include}",
                     "SUITESPARSE_LIB=#{ss_lib}"]
+    end
+
+    if build.with?("superlu_dist")
+      superlu_lib = "-L#{Formula["superlu_dist"].opt_lib} -lsuperlu_dist"
+      make_args += ["MFEM_USE_SUPERLU=YES",
+                    "SUPERLU_DIR=#{Formula["superlu_dist"].opt_prefix}",
+                    "SUPERLU_OPT=-I#{Formula["superlu_dist"].opt_include}",
+                    "SUPERLU_LIB=#{superlu_lib}"]
     end
 
     if build.with?("netcdf")


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

Commit adds superlu_dist support for solving linear systems in FEM via SuperLU_Dist.
