### PR TITLE
pocl: disable bottles

### DIFF
--- a/pocl.rb
+++ b/pocl.rb
@@ -3,10 +3,7 @@ class Pocl < Formula
   url "https://downloads.sourceforge.net/project/pocl/pocl-0.10.tar.gz"
   sha256 "e9c38f774a77e61f66d850b705a5ba42d49356c40e75733db4c4811e091e5088"
 
-  bottle do
-    sha256 "b79e64fe8bfeb42cc7a931fb67f6f02976f6d30798f4af928a32ee35eaa527d2" => :yosemite
-    sha256 "121b57ea1adeedc3c4523750ed9def5be63a54d147b8d30c85d612e2213224c3" => :mavericks
-  end
+  bottle :disable, "Last successful build and `make check` was with llvm 3.6.2"
 
   option "without-check", "Skip build-time tests (not recommended)"
 


### PR DESCRIPTION
The latest pocl (0.13) fails to build with the current llvm formula
(3.8.1) as well as with the prior (3.8.0):

```
error "isfinite is not a macro"
```

pocl 0.12 is not compatible with llvm 3.8*, but it does build with our
prior major llvm version, which was llvm (3.6.2), but this version is no
longer available in core and the version in homebrew/dupes differs.
Also, despite the successful build, there is still a test failure in
`make check`:

```
 16: Kernel functions length, distance, and normalize FAILED
(testsuite.at:174)
```

pocl 0.11 also builds with llvm 3.6.2, and `make check` succeeds, but
this may simply be because the test that failed for 0.12 appears to be
new.