### PR TITLE
libfolia: revision bump for icu4c, audit fix

### DIFF
--- a/libfolia.rb
+++ b/libfolia.rb
@@ -2,8 +2,8 @@ class Libfolia < Formula
   desc "XML annotation format for linguistically annotated language resources"
   homepage "https://proycon.github.io/folia/"
   url "http://software.ticc.uvt.nl/libfolia-0.13.tar.gz"
-  sha256 "a9fc9e475bb79629dc014cf7a78af64486c0f1bb902821ba2bb36c38c77a5d24"
-  revision 1
+  sha256 "a9111156362d8a68e06132aa7d1a57e28026fad5b90736efdd74f153548c8abd"
+  revision 2
 
   bottle do
     cellar :any
@@ -12,7 +12,9 @@ class Libfolia < Formula
     sha256 "4d541070af9aabc2bce4b1a46f3ad9360a7d6e9fc6e5128c074e77ed94d9fd42" => :mavericks
   end
 
-  option "without-check", "skip build-time checks (not recommended)"
+  option "without-test", "skip build-time checks (not recommended)"
+
+  deprecated_option "without-check" => "without_test"
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
@@ -25,7 +27,8 @@ class Libfolia < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
-    system "make", "check" if build.with? "check"
+    system "make"
+    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 end


### PR DESCRIPTION
### Have you:
- [X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change? _#3522 does this, but also includes a version upgrade and other formulae. I'm making a separate PR to un-block work on wopr/timbl and fix existing `libfolia` installs._
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors? _Fails due to missing test, but that's not a regression._
- [X] Built your formula locally prior to submission with `brew install <formula>`?
### Updates to existing formula: have you
- [ ] Removed the `revision` line, if any, when bumping the version number?
- [X] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass? _(no tests)_

---

I also added a separate `make` step, so the build and test would appear separately in the logs.
