### PR TITLE
open-mpi: migrate from core

### DIFF
--- a/bsponmpi.rb
+++ b/bsponmpi.rb
@@ -1,0 +1,17 @@
+class Bsponmpi < Formula
+  desc "Implements the BSPlib standard on top of MPI"
+  homepage "https://sourceforge.net/projects/bsponmpi/"
+  url "https://downloads.sourceforge.net/project/bsponmpi/bsponmpi/0.3/bsponmpi-0.3.tar.gz"
+  sha256 "bc90ca22155be9ff65aca4e964d8cd0bef5f0facef0a42bc1db8b9f822c92a90"
+
+  depends_on "scons" => :build
+  depends_on :mpi => [:cc, :cxx]
+
+  def install
+    # Don't install 'CVS' folders from tarball
+    rm_rf "include/CVS"
+    rm_rf "include/tools/CVS"
+    scons "-Q", "mode=release"
+    prefix.install "lib", "include"
+  end
+end

--- a/konoha.rb
+++ b/konoha.rb
@@ -1,0 +1,42 @@
+class Konoha < Formula
+  desc "Static scripting language with extensible syntax"
+  homepage "https://github.com/konoha-project/konoha3"
+  url "https://github.com/konoha-project/konoha3/archive/v0.1.tar.gz"
+  sha256 "e7d222808029515fe229b0ce1c4e84d0a35b59fce8603124a8df1aeba06114d3"
+  revision 1
+
+  head do
+    url "https://github.com/konoha-project/konoha3.git"
+
+    depends_on "openssl"
+  end
+
+  option "with-test", "Verify the build with make test (May currently fail)"
+
+  deprecated_option "tests" => "with-test"
+
+  depends_on "cmake" => :build
+  depends_on :mpi => [:cc, :cxx]
+  depends_on "pcre"
+  depends_on "json-c"
+  depends_on "sqlite"
+  depends_on "mecab" if MacOS.version >= :mountain_lion
+  depends_on :python if MacOS.version <= :snow_leopard # for python glue code
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      # `make test` currently fails. Reported upstream:
+      # https://github.com/konoha-project/konoha3/issues/438
+      system "make", "test" if build.with? "test"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test").write "System.p(\"Hello World!\");"
+    output = shell_output("#{bin}/konoha #{testpath}/test")
+    assert_match "(test:1) Hello World!", output
+  end
+end

--- a/lcdf-typetools.rb
+++ b/lcdf-typetools.rb
@@ -1,0 +1,15 @@
+class LcdfTypetools < Formula
+  desc "Manipulate OpenType and multiple-master fonts"
+  homepage "https://www.lcdf.org/type/"
+  url "https://www.lcdf.org/type/lcdf-typetools-2.104.tar.gz"
+  sha256 "d7985458ead0850cb9549ff1d619ffc18da5d7be892be5e1fce6048d510f0fff"
+
+  conflicts_with "open-mpi", :because => "both install same set of binaries."
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--without-kpathsea"
+    system "make", "install"
+  end
+end

--- a/mpich.rb
+++ b/mpich.rb
@@ -1,0 +1,90 @@
+class Mpich < Formula
+  desc "Implementation of the MPI Message Passing Interface standard"
+  homepage "https://www.mpich.org/"
+  url "https://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz"
+  mirror "https://fossies.org/linux/misc/mpich-3.2.tar.gz"
+  sha256 "0778679a6b693d7b7caff37ff9d2856dc2bfc51318bf8373859bfa74253da3dc"
+  revision 2
+
+  head do
+    url "git://git.mpich.org/mpich.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool"  => :build
+  end
+  deprecated_option "disable-fortran" => "without-fortran"
+
+  depends_on :fortran => :recommended
+
+  conflicts_with "open-mpi", :because => "both install mpi__ compiler wrappers"
+
+  def install
+    # Fix segfault; remove for next mpich releaase > 3.2
+    if build.stable? && ENV.compiler == :clang
+      inreplace "src/include/mpiimpl.h",
+        "} MPID_Request ATTRIBUTE((__aligned__(32)));",
+        "} ATTRIBUTE((__aligned__(32))) MPID_Request;"
+    end
+
+    if build.head?
+      # ensure that the consistent set of autotools built by homebrew is used to
+      # build MPICH, otherwise very bizarre build errors can occur
+      ENV["MPICH_AUTOTOOLS_DIR"] = HOMEBREW_PREFIX + "bin"
+      system "./autogen.sh"
+    end
+
+    args = [
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+      "--mandir=#{man}",
+    ]
+
+    args << "--disable-fortran" if build.without? "fortran"
+
+    system "./configure", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello.c").write <<-EOS.undent
+      #include <mpi.h>
+      #include <stdio.h>
+
+      int main()
+      {
+        int size, rank, nameLen;
+        char name[MPI_MAX_PROCESSOR_NAME];
+        MPI_Init(NULL, NULL);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Get_processor_name(name, &nameLen);
+        printf("[%d/%d] Hello, world! My name is %s.\\n", rank, size, name);
+        MPI_Finalize();
+        return 0;
+      }
+    EOS
+    system "#{bin}/mpicc", "hello.c", "-o", "hello"
+    system "./hello"
+    system "#{bin}/mpirun", "-np", "4", "./hello"
+    if build.with? "fortran"
+      (testpath/"hellof.f90").write <<-EOS.undent
+        program hello
+        include 'mpif.h'
+        integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
+        call MPI_INIT(ierror)
+        call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierror)
+        call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierror)
+        print*, 'node', rank, ': Hello Fortran world'
+        call MPI_FINALIZE(ierror)
+        end
+      EOS
+      system "#{bin}/mpif90", "hellof.f90", "-o", "hellof"
+      system "./hellof"
+      system "#{bin}/mpirun", "-np", "4", "./hellof"
+    end
+  end
+end

--- a/open-mpi.rb
+++ b/open-mpi.rb
@@ -1,0 +1,94 @@
+class OpenMpi < Formula
+  desc "High performance message passing library"
+  homepage "https://www.open-mpi.org/"
+  url "https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.0.tar.bz2"
+  sha256 "08b64cf8e3e5f50a50b4e5655f2b83b54653787bd549b72607d9312be44c18e0"
+
+  head do
+    url "https://github.com/open-mpi/ompi.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
+
+  option "with-mpi-thread-multiple", "Enable MPI_THREAD_MULTIPLE"
+  option "with-cxx-bindings", "Enable C++ MPI bindings (deprecated as of MPI-3.0)"
+  option :cxx11
+
+  deprecated_option "disable-fortran" => "without-fortran"
+  deprecated_option "enable-mpi-thread-multiple" => "with-mpi-thread-multiple"
+
+  depends_on :fortran => :recommended
+  depends_on :java => :optional
+  depends_on "libevent"
+
+  conflicts_with "mpich", :because => "both install mpi__ compiler wrappers"
+  conflicts_with "lcdf-typetools", :because => "both install same set of binaries."
+
+  def install
+    ENV.cxx11 if build.cxx11?
+
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --enable-ipv6
+      --with-libevent=#{Formula["libevent"].opt_prefix}
+      --with-sge
+    ]
+    args << "--with-platform-optimized" if build.head?
+    args << "--disable-mpi-fortran" if build.without? "fortran"
+    args << "--enable-mpi-thread-multiple" if build.with? "mpi-thread-multiple"
+    args << "--enable-mpi-java" if build.with? "java"
+    args << "--enable-mpi-cxx" if build.with? "cxx-bindings"
+
+    system "./autogen.pl" if build.head?
+    system "./configure", *args
+    system "make", "all"
+    system "make", "check"
+    system "make", "install"
+
+    # If Fortran bindings were built, there will be stray `.mod` files
+    # (Fortran header) in `lib` that need to be moved to `include`.
+    if build.with? "fortran"
+      include.install Dir["#{lib}/*.mod"]
+    end
+  end
+
+  test do
+    (testpath/"hello.c").write <<-EOS.undent
+      #include <mpi.h>
+      #include <stdio.h>
+
+      int main()
+      {
+        int size, rank, nameLen;
+        char name[MPI_MAX_PROCESSOR_NAME];
+        MPI_Init(NULL, NULL);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Get_processor_name(name, &nameLen);
+        printf("[%d/%d] Hello, world! My name is %s.\\n", rank, size, name);
+        MPI_Finalize();
+        return 0;
+      }
+    EOS
+    system bin/"mpicc", "hello.c", "-o", "hello"
+    system "./hello"
+    system bin/"mpirun", "-np", "4", "./hello"
+    (testpath/"hellof.f90").write <<-EOS.undent
+      program hello
+      include 'mpif.h'
+      integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
+      call MPI_INIT(ierror)
+      call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierror)
+      call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierror)
+      print*, 'node', rank, ': Hello Fortran world'
+      call MPI_FINALIZE(ierror)
+      end
+    EOS
+    system bin/"mpif90", "hellof.f90", "-o", "hellof"
+    system "./hellof"
+    system bin/"mpirun", "-np", "4", "./hellof"
+  end
+end


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/4274 and https://github.com/Homebrew/brew/pull/828.