### PR TITLE
cvblob download url changed

### DIFF
--- a/cvblob.rb
+++ b/cvblob.rb
@@ -1,6 +1,6 @@
 class Cvblob < Formula
   homepage "https://code.google.com/p/cvblob/"
-  url "https://cvblob.googlecode.com/files/cvblob-0.10.4-src.tgz"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cvblob/cvblob-0.10.4-src.tgz"
   sha256 "94eff3eed03370fac98e9d26a43405a3ac8eb3ca1621157c5738967b95c67bc1"
 
   depends_on "cmake" => :build


### PR DESCRIPTION
### Have you:

- [x ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x ] Not altered the `bottle` section?
- [x ] Checked that the tests still pass?

