### PR TITLE
xraylib: fix PYTHONPATH issue

### DIFF
--- a/xraylib.rb
+++ b/xraylib.rb
@@ -39,6 +39,8 @@ class Xraylib < Formula
     args << ((build.with? "ruby") ? "--enable-ruby" : "--disable-ruby")
     args << ((build.with? "pascal") ? "--enable-pascal" : "--disable-pascal")
 
+    ENV.delete "PYTHONPATH"
+
     if build.without?("python") && build.with?("python3")
       args << "--enable-python"
       args << "PYTHON=python3"


### PR DESCRIPTION
When building simultaneously the python2 and python3 bindings, the python3 bindings would end up in the wrong folder due to problems with PYTHONPATH being set to /usr/local/lib/python2.7/site-packages by Homebrew. 

Solution was to unset the variable in the Formula.