### PR TITLE
galsim: Depend on astropy.io.fits for FITS I/O

### DIFF
--- a/galsim.rb
+++ b/galsim.rb
@@ -15,10 +15,8 @@ class Galsim < Formula
   depends_on "boost-python"
   depends_on "tmv-cpp"
 
-  # FITS support should come from astropy.io.fits
-  # but don't complain if PyFITS is already installed
-  check_pyfits = system "python -c 'import pyfits' > /dev/null 2>&1"
-  depends_on "astropy" => :python if not check_pyfits
+  # FITS support should come from astropy.io.fits (PyFITS has been deprecated)
+  depends_on "astropy" => :python
   depends_on "numpy" => :python
   depends_on "nose" => :python if build.with? "check"
 

--- a/galsim.rb
+++ b/galsim.rb
@@ -15,8 +15,10 @@ class Galsim < Formula
   depends_on "boost-python"
   depends_on "tmv-cpp"
 
-  # pyfits should come from pip
-  depends_on "pyfits" => :python
+  # FITS support should come from astropy.io.fits
+  # but don't complain if PyFITS is already installed
+  check_pyfits = system "python -c 'import pyfits' > /dev/null 2>&1"
+  depends_on "astropy" => :python if not check_pyfits
   depends_on "numpy" => :python
   depends_on "nose" => :python if build.with? "check"
 
@@ -43,12 +45,17 @@ class Galsim < Formula
     pkgshare.install "examples"
   end
 
-  def caveats; <<-EOS.undent
-    The GalSim installer may warn you that #{lib}/python#{pyver} isn't in your python
-    search path. You may want to add all Homebrew python packages to the
-    default paths by running:
-       sudo bash -c 'echo \"#{lib}/python#{pyver}\" >> \\\\
-         /Library/Python/#{pyver}/site-packages/homebrew.pth'
+  def caveats
+      homebrew_site_packages = Language::Python.homebrew_site_packages
+      user_site_packages = Language::Python.user_site_packages "python"
+      s = <<-EOS.undent
+        If you use the Apple-provided Python instead of one from Homebrew, you
+        may want to add all Homebrew python packages to the default paths
+        by running:
+
+           mkdir -p #{user_site_packages}
+           echo 'import sys; sys.path.insert(1, "#{homebrew_site_packages}")' >> \\
+               #{user_site_packages}/homebrew.pth
     EOS
   end
 


### PR DESCRIPTION
~~Check for `astropy` availability, but only if `pyfits` is not available.~~

Depend on Astropy instead of PyFITS. Addresses #4232.