### PR TITLE
Update OpenCV GitHub links

### DIFF
--- a/opencv.rb
+++ b/opencv.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Requirements/cuda_requirement", __FILE__)
 class Opencv < Formula
   desc "Open source computer vision library"
   homepage "http://opencv.org/"
-  url "https://github.com/Itseez/opencv/archive/2.4.13.tar.gz"
+  url "https://github.com/opencv/opencv/archive/2.4.13.tar.gz"
   sha256 "94ebcca61c30034d5fb16feab8ec12c8a868f5162d20a9f0396f0f5f6d8bbbff"
-  head "https://github.com/Itseez/opencv.git", :branch => "2.4"
+  head "https://github.com/opencv/opencv.git", :branch => "2.4"
 
   bottle do
     revision 2

--- a/opencv3.rb
+++ b/opencv3.rb
@@ -6,32 +6,32 @@ class Opencv3 < Formula
   revision 3
 
   stable do
-    url "https://github.com/Itseez/opencv/archive/3.1.0.tar.gz"
+    url "https://github.com/opencv/opencv/archive/3.1.0.tar.gz"
     sha256 "f00b3c4f42acda07d89031a2ebb5ebe390764a133502c03a511f67b78bbd4fbf"
 
     resource "contrib" do
-      url "https://github.com/Itseez/opencv_contrib/archive/3.1.0.tar.gz"
+      url "https://github.com/opencv/opencv_contrib/archive/3.1.0.tar.gz"
       sha256 "ef2084bcd4c3812eb53c21fa81477d800e8ce8075b68d9dedec90fef395156e5"
     end
 
     patch do
-      # patch fixing crash after 100s when using capturing device https://github.com/Itseez/opencv/issues/5874
+      # patch fixing crash after 100s when using capturing device https://github.com/opencv/opencv/issues/5874
       # can be removed with next release
-      url "https://github.com/Itseez/opencv/commit/a2bda999211e8be9fbc5d40038fdfc9399de31fc.diff"
+      url "https://github.com/opencv/opencv/commit/a2bda999211e8be9fbc5d40038fdfc9399de31fc.diff"
       sha256 "c1f83ec305337744455c2b09c83624a7a3710cfddef2f398bb4ac20ea16197e2"
     end
 
     patch do
       # patch fixes build error https://github.com/Homebrew/homebrew-science/issues/3147 when not using --without-opencl
       # can be removed with next release
-      url "https://github.com/Itseez/opencv/commit/c7bdbef5042dadfe032dfb5d80f9b90bec830371.diff"
+      url "https://github.com/opencv/opencv/commit/c7bdbef5042dadfe032dfb5d80f9b90bec830371.diff"
       sha256 "106785f8478451575026e9bf3033e418d8509ffb93e62722701fa017dc043d91"
     end
 
     patch do
       # patch fixes build error when including example sources
       # can be removed with next release
-      url "https://github.com/Itseez/opencv/commit/cdb9c60dcb65e04e7c0bd6bef9b86841191c785a.diff"
+      url "https://github.com/opencv/opencv/commit/cdb9c60dcb65e04e7c0bd6bef9b86841191c785a.diff"
       sha256 "a14499a8c16545cf1bb206cfe0ed8a65697100dca9b2ae5274516d1213a1a32b"
     end
   end
@@ -44,10 +44,10 @@ class Opencv3 < Formula
   end
 
   head do
-    url "https://github.com/Itseez/opencv.git"
+    url "https://github.com/opencv/opencv.git"
 
     resource "contrib" do
-      url "https://github.com/Itseez/opencv_contrib.git"
+      url "https://github.com/opencv/opencv_contrib.git"
     end
   end
 
@@ -107,12 +107,12 @@ class Opencv3 < Formula
   cxxstdlib_check :skip
 
   resource "icv-macosx" do
-    url "https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_macosx_20151201.tgz", :using => :nounzip
+    url "https://raw.githubusercontent.com/opencv/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_macosx_20151201.tgz", :using => :nounzip
     sha256 "8a067e3e026195ea3ee5cda836f25231abb95b82b7aa25f0d585dc27b06c3630"
   end
 
   resource "icv-linux" do
-    url "https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_linux_20151201.tgz", :using => :nounzip
+    url "https://raw.githubusercontent.com/opencv/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_linux_20151201.tgz", :using => :nounzip
     sha256 "4333833e40afaa22c804169e44f9a63e357e21476b765a5683bcb3760107f0da"
   end
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

-----

Repository seems to have moved from Itseez/opencv to opencv/opencv. The Itseez organization page appears to be unused, with the last update to a repository in October 2015. In addition, the link to the Itseez website is dead, and it appears that Itseez was bought by Intel in late May 2016.