### PR TITLE
update nip2.rb to latest stable 8.4

### DIFF
--- a/nip2.rb
+++ b/nip2.rb
@@ -1,9 +1,8 @@
 class Nip2 < Formula
-  desc "A GUI for the VIPS image processing system"
+  desc "GUI for the VIPS image processing system"
   homepage "http://www.vips.ecs.soton.ac.uk/"
-  url "http://www.vips.ecs.soton.ac.uk/supported/8.2/nip2-8.2.tar.gz"
-  sha256 "18151e2185eb9db60196d98354ef751eb55ea9d3b55ef090f4a039125d465fca"
-  revision 1
+  url "http://www.vips.ecs.soton.ac.uk/supported/8.4/nip2-8.4.0.tar.gz"
+  sha256 "7a8c8b145216fbf2212de6eda4fbaff1884e3e1f8970f5e14e12a5df164e2c8a"
 
   bottle do
     cellar :any
@@ -12,7 +11,8 @@ class Nip2 < Formula
     sha256 "ada6912ef86789eec29a19aa883ae2fecfbbe0ea7d597d2c74db22da56b58c7c" => :mavericks
   end
 
-  option "with-check", "Enable build-time checking"
+  option "with-test", "Enable build-time testing"
+  deprecated_option "with-check" => "with-test"
 
   depends_on "pkg-config" => :build
   depends_on "XML::Parser" => :perl


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

fix a few things brew audit found too:

- Description shouldn't start with an indefinite article (A)
- Use '--with-test' instead of '--with-check'
- migrate '--with-check' with `deprecated_option`