### PR TITLE
RepeatScout: add mirror url

### DIFF
--- a/repeatscout.rb
+++ b/repeatscout.rb
@@ -3,8 +3,7 @@ class Repeatscout < Formula
   # doi "10.1093/bioinformatics/bti1018"
   # tag "bioinformatics"
 
-  url "http://repeatscout.bioprojects.org/RepeatScout-1.0.5.tar.gz"
-  mirror "http://www.repeatmasker.org/RepeatScout-1.0.5.tar.gz"
+  url "http://bix.ucsd.edu/repeatscout/RepeatScout-1.0.5.tar.gz"
   sha256 "bda6f782382f2b7dcb6a004b7da586d5046b3c12429b158e24787be62de6199c"
 
   bottle do


### PR DESCRIPTION
Download url was broken, added mirror url hosted at RepeatMasker
