### PR TITLE
asl: get rid of rpath

### DIFF
--- a/asl.rb
+++ b/asl.rb
@@ -3,6 +3,7 @@ class Asl < Formula
   homepage "http://www.ampl.com"
   url "https://github.com/ampl/mp/archive/3.1.0.tar.gz"
   sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
+  revision 1
 
   bottle do
     cellar :any
@@ -32,6 +33,7 @@ class Asl < Formula
     system "cmake", ".", *cmake_args
     system "make", "all"
     system "make", "test" if build.with? "test"
+    system "install_name_tool", "-change", "@rpath/libmp.3.dylib", lib/"libmp.dylib", "bin/libasl.dylib"
     system "make", "install"
     mkdir libexec
     mv bin, libexec/"bin"


### PR DESCRIPTION
There may be a better way to do this?!