### PR TITLE
mothur 1.38.1.1 (new formula)

### DIFF
--- a/mothur.rb
+++ b/mothur.rb
@@ -1,0 +1,24 @@
+class Mothur < Formula
+  desc "16s analysis software"
+  homepage "http://www.mothur.org"
+  url "https://github.com/mothur/mothur/archive/v1.38.1.1.tar.gz"
+  sha256 "e0c29e144a73b083e24c4138c9e7eee5969ceeddc57bcab9eb4094d48ce5bf97"
+
+  # tag "bioinformatics"
+  # doi "10.1128/AEM.01541-09"
+
+  depends_on "boost"
+
+  def install
+    boost = Formula["boost"]
+    inreplace "Makefile", '"\"Enter_your_boost_library_path_here\""', boost.opt_lib
+    inreplace "Makefile", '"\"Enter_your_boost_include_path_here\""', boost.opt_include
+    system "make"
+    bin.install "mothur", "uchime"
+  end
+
+  test do
+    system "#{bin}/mothur", "-h"
+    system "#{bin}/uchime", "--help"
+  end
+end


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) ~~and corrected all errors~~?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)

### Result of `brew audit --strict --online mothur`

```
  * Don't need to interpolate "boost.opt_lib" with inreplace
  * Don't need to interpolate "boost.opt_include" with inreplace
  * C: 14: col 71: Prefer `to_s` over string interpolation.
  * C: 15: col 71: Prefer `to_s` over string interpolation.
```

But I'm unsure how to replace paths in the Makefile without using inreplace.

