### PR TITLE
qgis, sumo: revision bumps for proj 4.9.3

### DIFF
--- a/qgis.rb
+++ b/qgis.rb
@@ -17,6 +17,7 @@ class Qgis < Formula
   homepage "http://www.qgis.org"
   url "http://qgis.org/downloads/qgis-1.8.0.tar.bz2"
   sha256 "700be4f81c4a6b6335a0217a6c476328c0ea02543d579a06dc1aaf60201303ab"
+  revision 1
 
   head "https://github.com/qgis/Quantum-GIS.git", :branch => "master"
 

--- a/sumo.rb
+++ b/sumo.rb
@@ -20,6 +20,7 @@ class Sumo < Formula
   depends_on "libpng"
   depends_on "jpeg"
   depends_on "libtiff"
+  depends_on "freetype"
   depends_on "proj"
   depends_on "gdal"
   depends_on "homebrew/x11/fox"

--- a/sumo.rb
+++ b/sumo.rb
@@ -12,7 +12,8 @@ class Sumo < Formula
     sha256 "ead5586821fcf6e32a1d8bbfe040b1f6349973f7963559fb0d44321f3ed84af1" => :mavericks
   end
 
-  option "with-check", "Enable additional build-time checking"
+  option "with-test", "Enable additional build-time checking"
+  deprecated_option "with-check" => "with-test"
 
   depends_on :x11
   depends_on "xerces-c"
@@ -25,7 +26,7 @@ class Sumo < Formula
   depends_on :python
 
   resource "gtest" do
-    url "https://googletest.googlecode.com/files/gtest-1.7.0.zip"
+    url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/googletest/gtest-1.7.0.zip"
     sha256 "247ca18dd83f53deb1328be17e4b1be31514cedfc1e3424f672bf11fd7e0d60d"
   end
 

--- a/sumo.rb
+++ b/sumo.rb
@@ -3,6 +3,7 @@ class Sumo < Formula
   homepage "https://sourceforge.net/projects/sumo/"
   url "https://downloads.sourceforge.net/project/sumo/sumo/version%200.25.0/sumo-all-0.25.0.tar.gz"
   sha256 "e56552e4cd997ccab59b5c6828ca1e044e71e3ffe8c780831bf5aa18c5fdd18a"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
Revision bumps for proj 4.9.3 (https://github.com/Homebrew/homebrew-core/pull/5289).

Formulae fail audits, but this isn't a regression.

`mbsystem` also needs a bump, but it has a new version out, so it'll be handled in #4396.
