### PR TITLE
Use --without-test instead of --without-check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,13 +20,13 @@ The `test do` block allows for a post-build test of software functionality sandb
 
 `make check` or equivalent should be enabled if the package provides it:
 
-    option "without-check", "Disable build-time checking (not recommended)"
+    option "without-test", "Skip build-time tests (not recommended)""
     ...
     system "make"
-    system "make", "check" if build.with? "check"
+    system "make", "check" if build.with? "test"
     system "make", "install"
 
-If this target takes an inordinate amount of resources or is otherwise problematic the option can be switched to `"with-check"`, disabling `make check` in the default build.
+If this target takes an inordinate amount of resources or is otherwise problematic the option can be switched to `"with-test"`, disabling `make check` in the default build.
 
 #### Revisions
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?

The `--without-check` option is deprecated. I updated CONTRIBUTING.md to reflect that contributors should use `--without-test` instead.

example output of `brew audit --strict --online` on a formula with the `--without-check` option:
```
* Use '--without-test' instead of '--without-check'. Migrate '--without-check' with deprecated_option
```