### PR TITLE
root6: Adding option `all`

### DIFF
--- a/root6.rb
+++ b/root6.rb
@@ -53,6 +53,7 @@ class Root6 < Formula
       -Dbuiltin_freetype=ON
       -Droofit=ON
       -Dminuit2=ON
+      #{config_opt("all")}
       #{config_opt("python")}
       #{config_opt("ssl", "openssl")}
       #{config_opt("xrootd")}


### PR DESCRIPTION
### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

Adding the option to install root6 with all the optional flags set to `ON`