### PR TITLE
field3d: fix test on case-sensitive file systems

### DIFF
--- a/field3d.rb
+++ b/field3d.rb
@@ -29,7 +29,7 @@ class Field3d < Formula
   end
 
   test do
-    system ENV.cxx, "-I#{include}", "-L#{lib}", "-lfield3d",
+    system ENV.cxx, "-I#{include}", "-L#{lib}", "-lField3D",
            "-I#{Formula["boost"].opt_include}",
            "-L#{Formula["boost"].opt_lib}", "-lboost_system",
            "-I#{Formula["hdf5"].opt_include}",


### PR DESCRIPTION
libField3D.dylib not libfield3d.dylib, so -lField3D not -lfield3d