### PR TITLE
OCE: update caveats

### DIFF
--- a/oce.rb
+++ b/oce.rb
@@ -52,7 +52,7 @@ class Oce < Formula
 
   def caveats; <<-EOF.undent
     Some apps will require this enviroment variable:
-      CASROOT=#{opt_share}/oce-#{version}
+      CASROOT=#{opt_share}/oce-#{version.to_s.split(".")[0..1].join(".")}
     EOF
   end
 


### PR DESCRIPTION
This uses the same logic that is used just below to actually _use_ `CASROOT`, and does not hardcode the version. I am not a Rubyist so I'm not sure if it's the best way, but it's what the original author did so I'm happy with it.
