### PR TITLE
cube 4.3.4

### DIFF
--- a/cube.rb
+++ b/cube.rb
@@ -1,7 +1,8 @@
 class Cube < Formula
+  desc "Performance report explorer for Scalasca and Score-P"
   homepage "http://apps.fz-juelich.de/scalasca/"
-  url "http://apps.fz-juelich.de/scalasca/releases/cube/4.2/dist/cube-4.2.2.tar.gz"
-  sha256 "67a7e2b3cf4927620fc4e987d6fae76b753a74303b3c9d30ea2e0937e64ae82a"
+  url "http://apps.fz-juelich.de/scalasca/releases/cube/4.3/dist/cube-4.3.4.tar.gz"
+  sha256 "34c55fc5d0c84942c0845a7324d84cde09f3bc1b3fae6a0f9556f7ea0e201065"
 
   bottle do
     cellar :any
@@ -10,25 +11,20 @@ class Cube < Formula
     sha256 "a6adbc6dfc92586c4bc71bc86d12f4d52834b58ae30880c75b055594c348e0f8" => :yosemite
   end
 
-  # qt is currently not available on 10.12
-  depends_on "qt" => :recommended if MacOS.version < :sierra
-
-  fails_with :clang do
-    cause <<-EOS.undent
-      Undefined symbols for architecture x86_64:
-      "cube::Cube::def_mirror(std::string const&)", referenced from:
-      MainWidget::readFile(QString) in cube-MainWidget.o
-    EOS
-  end if build.with? "qt"
+  depends_on "qt5"
+  depends_on "cmake" => :build
 
   def install
     ENV.deparallelize
-
     system "./configure",
       "--disable-debug",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
-      "--prefix=#{prefix}"
+      "--prefix=#{prefix}",
+      "--with-nocross-compiler-suite=clang",
+      "--with-qt-specs=macx-clang",
+      'CXXFLAGS="-stdlib=libc++"',
+      'LDFLAGS="-stdlib=libc++"'
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

This new version includes qt5 support (related to homebrew/homebrew-core#1705). I also added a description (related to #4251).

`ENV.deparallelize` is still needed.
