### PR TITLE
Fix broken hdf5.rb to point to latest release

### DIFF
--- a/hdf5.rb
+++ b/hdf5.rb
@@ -1,8 +1,8 @@
 class Hdf5 < Formula
   desc "File format designed to store large amounts of data"
   homepage "http://www.hdfgroup.org/HDF5"
-  url "https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.17.tar.bz2"
-  sha256 "fc35dd8fd8d398de6b525b27cc111c21fc79795ad6db1b1f12cb15ed1ee8486a"
+  url "https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18.tar.bz2"
+  sha256 "01c6deadf4211f86922400da82c7a8b5b50dc8fc1ce0b5912de3066af316a48c"
 
   bottle do
     rebuild 1


### PR DESCRIPTION
Formula is currently pointing to non-existing HDF5 source file: `hdf5-1.8.17.tar.bz2`, which has been removed from the HDF5 server and was replaced with hdf5-1.8.18.tar.bz2 on 2016-11-14.

I am aware of: https://github.com/Homebrew/homebrew-science/pull/4300 but that PR seems idle and requires additional work. It would be worth merging this in the mean-time to continue having a working HDF5 formula.