### PR TITLE
Update to GAP 4.8.6

### DIFF
--- a/gap.rb
+++ b/gap.rb
@@ -4,7 +4,6 @@ class Gap < Formula
   url "http://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p6_2016_11_12-14_25.tar.bz2"
   version "4.8.6"
   sha256 "cb401fde6b3e3c0095c55e9a92390bacd997cf5431149d53177a8cd76ab8c2a6"
-  revision 1
 
   bottle do
     cellar :any

--- a/gap.rb
+++ b/gap.rb
@@ -1,9 +1,9 @@
 class Gap < Formula
   desc "System for computational discrete algebra"
   homepage "http://www.gap-system.org/"
-  url "http://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p5_2016_09_25-11_49.tar.bz2"
-  version "4.8.5"
-  sha256 "08153c57e103a3899fb9603b976e3c3b581dd3f51f973db97ba73501b76967ab"
+  url "http://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p6_2016_11_12-14_25.tar.bz2"
+  version "4.8.6"
+  sha256 "cb401fde6b3e3c0095c55e9a92390bacd997cf5431149d53177a8cd76ab8c2a6"
   revision 1
 
   bottle do


### PR DESCRIPTION
GAP 4.8.6 has been released this week (http://mail.gap-system.org/pipermail/forum/2016/005368.html). This is straightforward update of the details of the new source archive and version number.