### PR TITLE
libqglviewer 2.6.4 (moving out of boneyard)

### DIFF
--- a/libqglviewer.rb
+++ b/libqglviewer.rb
@@ -1,0 +1,25 @@
+class Libqglviewer < Formula
+  desc "C++ Qt library to create OpenGL 3D viewers"
+  homepage "http://www.libqglviewer.com/"
+  url "http://www.libqglviewer.com/src/libQGLViewer-2.6.4.tar.gz"
+  sha256 "53daefd7981a3ff7719ee55c368226807791d916ed988dde0aa0eac89686389d"
+
+  head "https://github.com/GillesDebunne/libQGLViewer.git"
+
+  option :universal
+
+  depends_on "qt5"
+
+  def install
+    args = %W[
+      PREFIX=#{prefix}
+      DOC_DIR=#{doc}
+    ]
+    args << "CONFIG += x86 x86_64" if build.universal?
+
+    cd "QGLViewer" do
+      system "qmake", *args
+      system "make", "install"
+    end
+  end
+end


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

Based on [this disussion](https://github.com/Homebrew/homebrew-boneyard/pull/246#issuecomment-261472216) I propose to add `libqglviewer` to homebrew-science since it is an optional dependency to `g2o` and `dgtal`. This version includes support for `qt5`. 

No test is included: a test folder exists but only creates .app programs. Is there a proper way to use these as test?

`brew audit` fails due to the lack of test and the presence of the formula in homebrew-boneyard. Should I open a second pull request to homebrew-boneyard right away? 