### PR TITLE
Build Silo with HDF5 support (default, can be disabled)

### DIFF
--- a/silo.rb
+++ b/silo.rb
@@ -1,8 +1,9 @@
 class Silo < Formula
-  desc "LLNL Silo library. Allows to create databases for VisIt."
+  desc "LLNL mesh and field Silo I/O library. Allows creating databases for VisIt."
   homepage "https://wci.llnl.gov/simulation/computer-codes/silo"
   url "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2-bsd.tar.gz"
   sha256 "4b901dfc1eb4656e83419a6fde15a2f6c6a31df84edfad7f1dc296e01b20140e"
+  revision 1
 
   bottle do
     sha256 "121f4802d1e18e049f50360b9d6222867028320cea21a33ead806db3d55e1a3d" => :sierra
@@ -10,19 +11,31 @@ class Silo < Formula
     sha256 "61153eafb69d477e1270b07a951f402192d38c13759cd064801ad0d7ccd60e02" => :yosemite
   end
 
+  option "with-static", "Build as static instead of dynamic library"
+  option "without-lite-headers", "Do not install PDB lite headers"
+
   depends_on :x11 => :optional
   depends_on :fortran
   depends_on "readline"
+  depends_on "hdf5" => :recommended
 
   def install
     args = ["--prefix=#{prefix}"]
     args << "--enable-optimization"
+    args << "--with-zlib"
+    args << "--enable-install-lite-headers" if build.with? "lite-headers"
+    args << "--enable-shared" if build.without? "static"
     args << "--enable-x" if build.with? "x11"
+    args << "--with-hdf5=#{Formula["hdf5"].opt_prefix}" if build.with? "hdf5"
 
     ENV.append "LDFLAGS", "-L#{Formula["readline"].opt_lib} -lreadline"
     system "./configure", *args
     system "make", "install"
-    rm lib/"libsilo.settings"
+    if build.with? "hdf5"
+      rm lib/"libsiloh5.settings"
+    else
+      rm lib/"libsilo.settings"
+    end
   end
 
   test do
@@ -40,7 +53,16 @@ class Silo < Formula
             return 0;
         }
         EOS
-    system ENV.cc, "test.c", "-I#{opt_include}", "-L#{opt_lib}", "-lsilo", "-o", "test"
+    test_args = ["test.c", "-I#{opt_include}", "-L#{opt_lib}", "-o", "test"]
+    if build.with? "hdf5"
+      test_args << "-lsiloh5"
+      test_args << "-L#{Formula["hdf5"].opt_lib}"
+      test_args << "-lhdf5"
+    else
+      test_args << "-lsilo"
+    end
+    test_args << "-lm"
+    system ENV.cc, *test_args
     system "./test"
   end
 end


### PR DESCRIPTION
This change builds Silo by default as shared library with the HDF5 driver, necessary to read HDF5-based Silo files. (I also extended the description based on the title of https://silo.llnl.gov). It also installs the PDB lite headers by default (necessary to use the Hombrew/science Silo install when building VisIt). 

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [N/A] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [N/A] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
