### PR TITLE
mathgl: remove qt4 option

### DIFF
--- a/mathgl.rb
+++ b/mathgl.rb
@@ -27,8 +27,8 @@ class Mathgl < Formula
   depends_on :x11  if build.with? "fltk"
 
   if OS.linux?
-    depends_on :x11
     depends_on "linuxbrew/xorg/xorg"
+    depends_on :x11
     depends_on "homebrew/x11/freeglut"
   end
 

--- a/mathgl.rb
+++ b/mathgl.rb
@@ -27,7 +27,7 @@ class Mathgl < Formula
   depends_on :x11  if build.with? "fltk"
 
   if OS.linux?
-    depends_on "linuxbrew/xorg/xorg"
+    depends_on :x11
     depends_on "homebrew/x11/freeglut"
   end
 

--- a/mathgl.rb
+++ b/mathgl.rb
@@ -28,6 +28,7 @@ class Mathgl < Formula
 
   if OS.linux?
     depends_on :x11
+    depends_on "linuxbrew/xorg/xorg"
     depends_on "homebrew/x11/freeglut"
   end
 

--- a/mathgl.rb
+++ b/mathgl.rb
@@ -1,12 +1,4 @@
 class Mathgl < Formula
-  def self.with_qt?(version)
-    version.to_s == ARGV.value("with-qt")
-  end
-
-  def with_qt?(version)
-    self.class.with_qt? version
-  end
-
   desc "Scientific graphics library"
   homepage "http://mathgl.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mathgl/mathgl/mathgl%202.3.5/mathgl-2.3.5.1.tar.gz"
@@ -20,7 +12,6 @@ class Mathgl < Formula
     sha256 "4abd73a027a09970f2324ad92dc31aa642346e6c600bf29cb7787bc47b451c0c" => :yosemite
   end
 
-  option "with-qt=", "Build with Qt 4 or 5 support"
   option "with-openmp", "Enable OpenMP multithreading"
 
   depends_on "cmake"   => :build
@@ -32,9 +23,9 @@ class Mathgl < Formula
   depends_on "fltk"    => :optional
   depends_on "wxmac"   => :optional
   depends_on "giflib"  => :optional
-  depends_on "qt"  if with_qt? 4
-  depends_on "qt5" if with_qt? 5
+  depends_on "qt5" => :optional
   depends_on :x11  if build.with? "fltk"
+  depends_on "homebrew/x11/freeglut" if OS.linux?
 
   needs :openmp if build.with? "openmp"
 
@@ -50,12 +41,18 @@ class Mathgl < Formula
 
     args << "-Denable-openmp=" + ((build.with? "openmp") ? "ON" : "OFF")
     args << "-Denable-pthread=" + ((build.with? "openmp") ? "OFF" : "ON")
-    args << "-Denable-qt4=ON"     if with_qt? 4
-    args << "-Denable-qt5=ON"     if with_qt? 5
+    args << "-Denable-qt5=ON"     if build.with? "qt5"
+    # the JSON samples need QtWebKit
+    args << "-Denable-json-sample=OFF" if build.with? "qt5"
     args << "-Denable-gif=ON"     if build.with? "giflib"
     args << "-Denable-hdf5_18=ON" if build.with? "hdf5"
     args << "-Denable-fltk=ON"    if build.with? "fltk"
     args << "-Denable-wx=ON"      if build.with? "wxmac"
+    # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
+    if OS.mac?
+      glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"
+      args << "-DGLUT_glut_LIBRARY=#{glut_lib}"
+    end
     args << ".."
     mkdir "brewery" do
       system "cmake", *args

--- a/mathgl.rb
+++ b/mathgl.rb
@@ -28,7 +28,6 @@ class Mathgl < Formula
 
   if OS.linux?
     depends_on "linuxbrew/xorg/xorg"
-    depends_on :x11
     depends_on "homebrew/x11/freeglut"
   end
 

--- a/mathgl.rb
+++ b/mathgl.rb
@@ -25,7 +25,11 @@ class Mathgl < Formula
   depends_on "giflib"  => :optional
   depends_on "qt5" => :optional
   depends_on :x11  if build.with? "fltk"
-  depends_on "homebrew/x11/freeglut" if OS.linux?
+
+  if OS.linux?
+    depends_on "linuxbrew/xorg/xorg"
+    depends_on "homebrew/x11/freeglut"
+  end
 
   needs :openmp if build.with? "openmp"
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

This fixes `mathgl` for issue #4595. 
