### PR TITLE
cmor: make keg-only

### DIFF
--- a/cmor.rb
+++ b/cmor.rb
@@ -3,6 +3,7 @@ class Cmor < Formula
   homepage "http://www2-pcmdi.llnl.gov/cmor"
   url "https://github.com/PCMDI/cmor/archive/3.1.2.tar.gz"
   sha256 "ee58b6d405f081e4e0633af931b7992f1a570953b71ece17c01ab9e15889211a"
+  revision 1
   # doi "10.5281/zenodo.61943"
 
   bottle do
@@ -10,6 +11,8 @@ class Cmor < Formula
     sha256 "d01148d52e2f26a1eccf46d1351bf1131434ba488f533858c8401ee6ad9e0898" => :yosemite
     sha256 "8548ba7e8ce1933abcb59b9dcaf3305842ecf2d5f1cdcbfda14a28809e2a5617" => :mavericks
   end
+
+  keg_only "Conflicts with json-c in main repository."
 
   depends_on "ossp-uuid"
   depends_on "udunits"


### PR DESCRIPTION
conflicts with homebrew/core/json-c