### PR TITLE
ncview: use pipe_output in the test

### DIFF
--- a/ncview.rb
+++ b/ncview.rb
@@ -23,6 +23,6 @@ class Ncview < Formula
   end
 
   test do
-    assert_match /Ncview #{version} /, shell_output("#{bin}/ncview -c 2>&1")
+    assert_match "Ncview #{version}", pipe_output("#{bin}/ncview -c 2>&1")
   end
 end


### PR DESCRIPTION
This avoids asserting the exit code is 0, which is not the case unless
the test is run from the macOS GUI.