### PR TITLE
opencv: Fix "ld: framework not found CoreImage" on old OSs

### DIFF
--- a/opencv.rb
+++ b/opencv.rb
@@ -57,6 +57,12 @@ class Opencv < Formula
   # in Homebrew anyway. Will depend on openexr if it's installed.
   depends_on "ffmpeg" => :optional
 
+  # Workaround for https://github.com/opencv/opencv/issues/7606
+  patch do
+    url "https://github.com/DabeDotCom/opencv/commit/6292fb62682f94a7efd7979401d41d278cac1262.diff"
+    sha256 "1df24d5ee16f6b9c0364d7aa8a125236c3b4feef911648ad37690d2654a5fb93"
+  end
+
   def arg_switch(opt)
     (build.with? opt) ? "ON" : "OFF"
   end


### PR DESCRIPTION
A work-around for [https://github.com/opencv/opencv/issues/7606
which affects older Macs having Xcode versions less than 7.0 (i.e.,
before El Capitan).

N.B. — This patch will [hopefully!] become unnecessary if the upstream PR is accepted...

### Have you:

- [✔] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [✔] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [✔] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [✔] Built your formula locally prior to submission with `brew install <formula>`?