### PR TITLE
vcftools 0.1.14

### DIFF
--- a/vcftools.rb
+++ b/vcftools.rb
@@ -4,7 +4,7 @@ class Vcftools < Formula
   # doi "10.1093/bioinformatics/btr330"
   # tag "bioinformatics"
 
-  url "https://github.com/vcftools/vcftools/archive/v0.1.13.tar.gz"
+  url "https://github.com/vcftools/vcftools/archive/v0.1.14.tar.gz"
   sha256 "0e241da57bc7048161d3751a1be842ad36e6a43f803c91cc9ef18aa15b3fc85e"
 
   head "https://github.com/vcftools/vcftools.git"


### PR DESCRIPTION
There is a new version of vcftools (v0.1.14)

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
