### PR TITLE
Opencv 3.2

### DIFF
--- a/opencv3.rb
+++ b/opencv3.rb
@@ -3,43 +3,16 @@ require File.expand_path("../Requirements/cuda_requirement", __FILE__)
 class Opencv3 < Formula
   desc "Open source computer vision library, version 3"
   homepage "http://opencv.org/"
-  revision 4
+  revision 5
 
   stable do
-    url "https://github.com/opencv/opencv/archive/3.1.0.tar.gz"
-    sha256 "f00b3c4f42acda07d89031a2ebb5ebe390764a133502c03a511f67b78bbd4fbf"
+    url "https://github.com/opencv/opencv/archive/3.2.0.tar.gz"
+    sha256 "b9d62dfffb8130d59d587627703d5f3e6252dce4a94c1955784998da7a39dd35"
 
     resource "contrib" do
-      url "https://github.com/opencv/opencv_contrib/archive/3.1.0.tar.gz"
-      sha256 "ef2084bcd4c3812eb53c21fa81477d800e8ce8075b68d9dedec90fef395156e5"
+      url "https://github.com/opencv/opencv_contrib/archive/3.2.0.tar.gz"
+      sha256 "1e2bb6c9a41c602904cc7df3f8fb8f98363a88ea564f2a087240483426bf8cbe"
     end
-
-    patch do
-      # patch fixing crash after 100s when using capturing device https://github.com/opencv/opencv/issues/5874
-      # can be removed with next release
-      url "https://github.com/opencv/opencv/commit/a2bda999211e8be9fbc5d40038fdfc9399de31fc.diff"
-      sha256 "c1f83ec305337744455c2b09c83624a7a3710cfddef2f398bb4ac20ea16197e2"
-    end
-
-    patch do
-      # patch fixes build error https://github.com/Homebrew/homebrew-science/issues/3147 when not using --without-opencl
-      # can be removed with next release
-      url "https://github.com/opencv/opencv/commit/c7bdbef5042dadfe032dfb5d80f9b90bec830371.diff"
-      sha256 "106785f8478451575026e9bf3033e418d8509ffb93e62722701fa017dc043d91"
-    end
-
-    patch do
-      # patch fixes build error when including example sources
-      # can be removed with next release
-      url "https://github.com/opencv/opencv/commit/cdb9c60dcb65e04e7c0bd6bef9b86841191c785a.diff"
-      sha256 "a14499a8c16545cf1bb206cfe0ed8a65697100dca9b2ae5274516d1213a1a32b"
-    end
-  end
-
-  bottle do
-    sha256 "a09c8a723c7266f790db768d8a89c50e367071fa4c0015bdf632a94af37194fb" => :el_capitan
-    sha256 "7c089cc50c50aed8a7f53096a61fe538eaec502a8d6e5be6a73f0bfa97c6bc75" => :yosemite
-    sha256 "3492582fc4888a77d132a84444ff4271a4a6d8e49cb274abeb5fa6c0cc95e2df" => :mavericks
   end
 
   head do
@@ -58,6 +31,7 @@ class Opencv3 < Formula
   option "with-contrib", 'Build "extra" contributed modules'
   option "with-cuda", "Build with CUDA v7.0+ support"
   option "with-examples", "Install C and python examples (sources)"
+  option "with-apps", "Build utility applications (used for example to train classifiers, interactive camera calibration, ...). Since this is a keg only formula, apps can be found in /usr/local/Cellar/opencv3/3.2.0_5/bin"
   option "with-java", "Build with Java support"
   option "with-opengl", "Build with OpenGL support (must use --with-qt5)"
   option "with-quicktime", "Use QuickTime for Video I/O instead of QTKit"
@@ -150,6 +124,7 @@ class Opencv3 < Formula
     args << "-DWITH_QT=" + (with_qt ? "ON" : "OFF")
     args << "-DWITH_TBB=" + arg_switch("tbb")
     args << "-DWITH_VTK=" + arg_switch("vtk")
+    args << "-DBUILD_opencv_apps=" + arg_switch("apps")
 
     if build.include? "32-bit"
       args << "-DCMAKE_OSX_ARCHITECTURES=i386"

--- a/opencv3.rb
+++ b/opencv3.rb
@@ -3,7 +3,6 @@ require File.expand_path("../Requirements/cuda_requirement", __FILE__)
 class Opencv3 < Formula
   desc "Open source computer vision library, version 3"
   homepage "http://opencv.org/"
-  revision 5
 
   stable do
     url "https://github.com/opencv/opencv/archive/3.2.0.tar.gz"
@@ -26,8 +25,7 @@ class Opencv3 < Formula
   keg_only "opencv3 and opencv install many of the same files."
 
   deprecated_option "without-tests" => "without-test"
-
-  option "32-bit"
+  deprecated_option "32-bit" => "with-32-bit"
   option "with-contrib", 'Build "extra" contributed modules'
   option "with-cuda", "Build with CUDA v7.0+ support"
   option "with-examples", "Install C and python examples (sources)"


### PR DESCRIPTION
### Updated existing opencv3 formula from from opencv version 3.1 to 3.2
Opencv 3.2 was officially released 12/23/2016. I updated the main and contrib sources to the new 3.2 version. I also added the `with-apps` option and added the `deprecated_option "32-bit" => "with-32-bit"` to make the formula better comply with the guidelines. The formula built on my system 10.12.2 without errors and imports into python 2 successfully. I tested it using the options `--with-contrib --with-examples --with-apps`.

I also removed the patches since I verified they are all now in version 3.2.

I removed the revision line, but please double check that this was the correct thing to do. I am not an expert on brew formulas.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?