### PR TITLE
cudainfo 0.9 (new formula)

### DIFF
--- a/cudainfo.rb
+++ b/cudainfo.rb
@@ -1,0 +1,27 @@
+require File.expand_path("../Requirements/cuda_requirement", __FILE__)
+
+class Cudainfo < Formula
+  desc "CLI tool that shows the properties of installed CUDA GPUs"
+  homepage "https://github.com/pwnall/cudainfo"
+
+  stable do
+    url "https://github.com/pwnall/cudainfo/archive/v0.9.tar.gz"
+    sha256 "bf58ca69df86d9b7ff4948fd5fda249410c7ee0677fb2bef6664f8b0399b33fc"
+  end
+
+  head do
+    url "https://github.com/pwnall/cudainfo.git"
+  end
+
+  depends_on CudaRequirement
+
+  def install
+    system "make", "cudainfo"
+    bin.install "cudainfo"
+  end
+
+  test do
+    cuda_info = YAML.load Utils.popen_read("cudainfo")
+    assert !cuda_info.empty?
+  end
+end


### PR DESCRIPTION
This is a `cpuinfo` equivalent for CUDA cards whose output happens to be both machine-readable and (sort of) human-friendly.

I wrote this tool to automate the step of figuring out what compute version a CUDA card has, which is needed e.g., to build [tensorflow](https://www.tensorflow.org/). The manual instructions included in most CUDA libraries involve going to [a nvidia page](https://developer.nvidia.com/cuda-gpus) and finding the computer's GPU card in one of the tables there. I hope that this tool will eventually mean that no scientist ever has to visit that page again to get an ML framework set up.

So, while this tool isn't scientific on its own, I expect that it will be used to install other software that belongs in homebrew-science, such as caffe and tensorflow. For example, I am using it in my [work-in-progress tensorflow formula](https://github.com/pwnall/homebrew-science/blob/tensorflow/tensorflow.rb).

I hope that you'll accept this formula, as I think it will make people's lives easier. I look forward to your feedback!

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)
