### PR TITLE
hypre 2.11.1

### DIFF
--- a/hypre.rb
+++ b/hypre.rb
@@ -1,10 +1,9 @@
 class Hypre < Formula
-  desc "A library of high performance preconditioners that features parallel multigrid methods for both structured and unstructured grid problems"
+  desc "Library featuring parallel multigrid methods for grid problems"
   homepage "http://computation.llnl.gov/casc/hypre/software.html"
-  url "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/hypre-2.10.0b-p2.tar.gz"
-  version "2.10.0b-p2"
-  sha256 "76414e693e5381e352e759c851c8cd5969dba7001b1dc153fe0f1ff60a5bb168"
-  revision 1
+  url "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/hypre-2.11.1.tar.gz"
+  mirror "http://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/download/hypre-2.11.1.tar.gz"
+  sha256 "6bb2ff565ff694596d0e94d0a75f0c3a2cd6715b8b7652bc71feb8698554db93"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,17 +12,20 @@ class Hypre < Formula
     sha256 "83420dd19fa18da92767c3495048450faa6e1ac84bf09cbbff97fb7de5b2db3c" => :mavericks
   end
 
-  depends_on :fortran => :recommended
-  depends_on :mpi => [:cc, :cxx, :f90, :f77, :recommended]
-  depends_on "openblas" => :optional
-
-  option "without-check", "Skip build-time tests (not recommended)"
+  option "without-test", "Skip build-time tests (not recommended)"
   option "with-superlu", "Use internal SuperLU routines"
   option "with-fei", "Use internal FEI routines"
   option "with-mli", "Use internal MLI routines"
   option "without-accelerate", "Build without Accelerate framework (use internal BLAS routines)"
   option "with-debug", "Build with debug flags"
   option "with-bigint", "Build with 64-bit indices"
+
+  deprecated_option "with-check" => "with-test"
+
+  depends_on "veclibfort" if build.without?("openblas") && OS.mac?
+  depends_on :fortran => :recommended
+  depends_on :mpi => [:cc, :cxx, :f90, :f77, :recommended]
+  depends_on "openblas" => (OS.mac? ? :optional : :recommended)
 
   def install
     cd "src" do
@@ -74,14 +76,13 @@ class Hypre < Formula
         ENV["CXX"] = ENV["MPICXX"]
         ENV["F77"] = ENV["MPIF77"]
         ENV["FC"] = ENV["MPIFC"]
+        # MPI library strings for linking depends on compilers
+        # enabled.  Only the C library strings are needed (without the
+        # lib), because hypre is a C library.
         config_args += ["--with-MPI",
                         "--with-MPI-include=#{HOMEBREW_PREFIX}/include",
                         "--with-MPI-lib-dirs=#{HOMEBREW_PREFIX}/lib",
-                        # MPI library strings for linking depends on compilers
-                        # enabled.  Only the C library strings are needed (without the
-                        # lib), because hypre is a C library.
-                        "--with-MPI-libs=mpi",
-                       ]
+                        "--with-MPI-libs=mpi"]
       else
         config_args << "--without-MPI"
       end
@@ -95,78 +96,16 @@ class Hypre < Formula
       system "make", "all"
       system "make", "install"
 
-      if build.with? "check"
+      if build.with? "test"
         system "make", "check"
         system "make", "test"
         system "./test/ij"
         system "./test/struct"
         system "./test/sstruct", "-in", "test/sstruct.in.default", "-solver", "40", "-rhsone"
 
-        cd "examples" do
-          # The examples makefile does not use any of the variables from the
-          # makefile in its parent directory. Examples that use the IJ
-          # interface hang due to lack of LAPACK linkage, so a LAPACK
-          # flag must be added; this method of doing so is the least
-          # intrusive, and a patch is unlikely to be accepted upstream.
-          # Overriding makefile variables at the command line is unworkable
-          # here because the LFLAGS variable must be overridden, and LFLAGS
-          # contains other makefile variable substitutions.
-          lapack_flag = build.with?("openblas") ? "openblas" : "lapack"
-          inreplace "Makefile", "-lstdc++", "-lstdc++ -l#{lapack_flag}"
-
-          # Hack to excise Fortran examples from "make all"; they are still
-          # in the "make fortran" target, thus making it easier to implement
-          # conditional compilation and execution. Also won't be accepted
-          # upstream.
-          inreplace "Makefile", "ex5 ex5f", "ex5"
-          inreplace "Makefile", "ex12 ex12f", "ex12"
-
-          # Hack to excise FEI example from "make all"; to test, use
-          # "make ex10" instead.
-          inreplace "Makefile", "ex9 ex10", "ex9"
-
-          # Now make all compiles all examples EXCEPT:
-          # - Fortran examples (use "make fortran")
-          # - 64-bit indexing examples (use "make 64bit")
-          # - Babel examples (use "make babel", not implemented)
-          # - FEI example (use "make ex10", requires Babel, not implemented)
-          if build.without? "bigint"
-
-            # For some reason, this Makefile doesn't include the settings of
-            # the main Makefile.
-            local_args = ["CC=#{ENV["MPICC"]}", "F77=#{ENV["MPIF77"]}", "CXX=#{ENV["MPICXX"]}", "F90=#{ENV["MPIFC"]}"]
-            system "make", "all", *local_args
-
-            # Example run commands taken from source file comments in headers
-            system "mpiexec", "-np", "2", "./ex1"
-            system "mpiexec", "-np", "2", "./ex2"
-            system "mpiexec", "-np", "16", "./ex3", "-n", "33", "-solver", "-v", "1", "1"
-            system "mpiexec", "-np", "16", "./ex4", "-n", "33", "-solver", "10", "-K", "3", "-B", "0", "-C", "1", "-U0", "2", "-F", "4"
-            system "mpiexec", "-np", "4", "./ex5"
-            system "mpiexec", "-np", "2", "./ex6"
-            system "mpiexec", "-np", "16", "./ex7", "-n", "33", "-solver", "10", "-K", "3", "-B", "0", "-C", "1", "-U0", "2", "-F", "4"
-            system "mpiexec", "-np", "2", "./ex8"
-            system "mpiexec", "-np", "16", "./ex9", "-n", "33", "-solver", "0", "-v", "1", "1"
-            system "mpiexec", "-np", "4", "./ex11"
-            system "mpiexec", "-np", "2", "./ex12", "-pfmg"
-            system "mpiexec", "-np", "2", "./ex12", "-boomeramg"
-            system "mpiexec", "-np", "6", "./ex13", "-n", "10"
-            system "mpiexec", "-np", "6", "./ex14", "-n", "10"
-            system "mpiexec", "-np", "8", "./ex15", "-n", "10"
-
-            if build.with? :fortran
-              system "make", "fortran"
-
-              system "mpiexec", "-np", "4", "./ex5f"
-              system "mpiexec", "-np", "2", "./ex12f"
-            end
-          else
-            system "make", "64bit"
-
-            system "mpiexec", "-np", "4", "./ex5big"
-            system "mpiexec", "-np", "8", "./ex15big", "-n", "10"
-          end
-        end if build.with? :mpi
+        if build.with? :mpi
+          build_mpi_examples
+        end
       end
     end
   end
@@ -176,5 +115,87 @@ class Hypre < Formula
 
       http://computation.llnl.gov/casc/hypre/download/hypre-2.10.0b_reg.html
     EOS
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include "HYPRE_struct_ls.h"
+
+      int main(int argc, char* argv[])
+      {
+          HYPRE_StructGrid grid;
+      }
+    EOS
+
+    system ENV.cxx, "test.cpp", "-o", "test"
+    system "./test"
+  end
+
+  def build_mpi_examples
+    cd "examples" do
+      # The examples makefile does not use any of the variables from the
+      # makefile in its parent directory. Examples that use the IJ
+      # interface hang due to lack of LAPACK linkage, so a LAPACK
+      # flag must be added; this method of doing so is the least
+      # intrusive, and a patch is unlikely to be accepted upstream.
+      # Overriding makefile variables at the command line is unworkable
+      # here because the LFLAGS variable must be overridden, and LFLAGS
+      # contains other makefile variable substitutions.
+      lapack_flag = build.with?("openblas") ? "openblas" : "lapack"
+      inreplace "Makefile", "-lstdc++", "-lstdc++ -l#{lapack_flag}"
+
+      # Hack to excise Fortran examples from "make all"; they are still
+      # in the "make fortran" target, thus making it easier to implement
+      # conditional compilation and execution. Also won't be accepted
+      # upstream.
+      inreplace "Makefile", "ex5 ex5f", "ex5"
+      inreplace "Makefile", "ex12 ex12f", "ex12"
+
+      # Hack to excise FEI example from "make all"; to test, use
+      # "make ex10" instead.
+      inreplace "Makefile", "ex9 ex10", "ex9"
+
+      # Now make all compiles all examples EXCEPT:
+      # - Fortran examples (use "make fortran")
+      # - 64-bit indexing examples (use "make 64bit")
+      # - Babel examples (use "make babel", not implemented)
+      # - FEI example (use "make ex10", requires Babel, not implemented)
+      if build.without? "bigint"
+
+        # For some reason, this Makefile doesn't include the settings of
+        # the main Makefile.
+        local_args = ["CC=#{ENV["MPICC"]}", "F77=#{ENV["MPIF77"]}", "CXX=#{ENV["MPICXX"]}", "F90=#{ENV["MPIFC"]}"]
+        system "make", "all", *local_args
+
+        # Example run commands taken from source file comments in headers
+        system "mpiexec", "-np", "2", "./ex1"
+        system "mpiexec", "-np", "2", "./ex2"
+        system "mpiexec", "-np", "16", "./ex3", "-n", "33", "-solver", "-v", "1", "1"
+        system "mpiexec", "-np", "16", "./ex4", "-n", "33", "-solver", "10", "-K", "3", "-B", "0", "-C", "1", "-U0", "2", "-F", "4"
+        system "mpiexec", "-np", "4", "./ex5"
+        system "mpiexec", "-np", "2", "./ex6"
+        system "mpiexec", "-np", "16", "./ex7", "-n", "33", "-solver", "10", "-K", "3", "-B", "0", "-C", "1", "-U0", "2", "-F", "4"
+        system "mpiexec", "-np", "2", "./ex8"
+        system "mpiexec", "-np", "16", "./ex9", "-n", "33", "-solver", "0", "-v", "1", "1"
+        system "mpiexec", "-np", "4", "./ex11"
+        system "mpiexec", "-np", "2", "./ex12", "-pfmg"
+        system "mpiexec", "-np", "2", "./ex12", "-boomeramg"
+        system "mpiexec", "-np", "6", "./ex13", "-n", "10"
+        system "mpiexec", "-np", "6", "./ex14", "-n", "10"
+        system "mpiexec", "-np", "8", "./ex15", "-n", "10"
+
+        if build.with? :fortran
+          system "make", "fortran"
+
+          system "mpiexec", "-np", "4", "./ex5f"
+          system "mpiexec", "-np", "2", "./ex12f"
+        end
+      else
+        system "make", "64bit"
+
+        system "mpiexec", "-np", "4", "./ex5big"
+        system "mpiexec", "-np", "8", "./ex15big", "-n", "10"
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes following audit failures

  * `option` (line 19) should be put before `depends_on` (line 17)
  * A `test do` test block should be added
  * Description is too long. "name: desc" should be less than 80 characters.
    Length is calculated as hypre + desc. (currently 144)
  * Description shouldn't start with an indefinite article (A)
  * Use '--without-test' instead of '--without-check'. Migrate '--without-check' with `deprecated_option`.
  * C: 83: col 24: Closing array brace must be on the same line as the last array element when opening brace is on the same line as the first array element.
  * C: 104: col 9: Favor a normal if-statement over a modifier clause in a multiline statement.
  * C: 156: col 13: Avoid more than 3 levels of block nesting.

- Added a simple test
- Added veclibfort depency as suggested in #3597
- Depend on openblas for linux to prevent linking errors

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
