### PR TITLE
matplotlib: Removed framework inreplace for building 2.0.0 without CLT.

### DIFF
--- a/matplotlib.rb
+++ b/matplotlib.rb
@@ -142,13 +142,6 @@ class Matplotlib < Formula
               "'darwin': ['/usr/local/'",
               "'darwin': ['#{HOMEBREW_PREFIX}'"
 
-    # Apple has the Frameworks (esp. Tk.Framework) in a different place
-    unless MacOS::CLT.installed?
-      inreplace "setupext.py",
-                "'/System/Library/Frameworks/',",
-                "'#{MacOS.sdk_path}/System/Library/Frameworks',"
-    end
-
     Language::Python.each_python(build) do |python, version|
       bundle_path = libexec/"lib/python#{version}/site-packages"
       bundle_path.mkpath


### PR DESCRIPTION
The inreplace for changing the Frameworks paths is no longer needed and breaks the build on matplotlib>=1.5.2 because runtime loading of Tk was implemented in https://github.com/matplotlib/matplotlib/commit/b80e0f122ee6f01e036282087ba9ddad63311c62 :

```
Error: inreplace failed
setupext.py:
  expected replacement of "'/System/Library/Frameworks/'," with "'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks',"
```

### I Have:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
