### PR TITLE
netcdf: enable cxx and cxx compat options

### DIFF
--- a/dealii.rb
+++ b/dealii.rb
@@ -3,7 +3,7 @@ class Dealii < Formula
   homepage "http://www.dealii.org"
   url "https://github.com/dealii/dealii/releases/download/v8.4.2/dealii-8.4.2.tar.gz"
   sha256 "ec7c00fadc9d298d1a0d16c08fb26818868410a9622c59ba624096872f3058e4"
-  revision 5
+  revision 6
 
   head "https://github.com/dealii/dealii.git"
 
@@ -32,7 +32,7 @@ class Dealii < Formula
   depends_on "hdf5"         => [:recommended] + mpidep
   depends_on "metis"        => :recommended
   depends_on "muparser"     => :recommended if MacOS.version != :mountain_lion # Undefined symbols for architecture x86_64
-  depends_on "netcdf"       => [:recommended, "with-fortran", "with-cxx-compat"]
+  depends_on "netcdf"       => [:recommended, "with-fortran"]
   depends_on "oce"          => :recommended
   depends_on "p4est"        => [:recommended] + openblasdep if build.with? "mpi"
   depends_on "parmetis"     => :recommended if build.with? "mpi"

--- a/netcdf.rb
+++ b/netcdf.rb
@@ -4,7 +4,7 @@ class Netcdf < Formula
   url "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz"
   mirror "http://www.gfd-dennou.org/library/netcdf/unidata-mirror/netcdf-4.4.1.1.tar.gz"
   sha256 "4d44c6f4d02a8faf10ea619bfe1ba8224cd993024f4da12988c7465f663c8cae"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -13,14 +13,10 @@ class Netcdf < Formula
     sha256 "dac02e43ee61aa8bf59341d8a82a99c23f771cbe9705d5fbd8b577a6741abd94" => :yosemite
   end
 
-  option "without-cxx", "Don't compile C++ bindings"
-  option "with-cxx-compat", "Compile C++ bindings for compatibility"
   option "without-test", "Disable checks (not recommended)"
 
-  deprecated_option "enable-fortran" => "with-fortran"
-  deprecated_option "disable-cxx" => "without-cxx"
-  deprecated_option "enable-cxx-compat" => "with-cxx-compat"
   deprecated_option "without-check" => "without-test"
+  deprecated_option "enable-fortran" => "with-fortran"
 
   depends_on "cmake" => :build
   depends_on "hdf5"
@@ -71,16 +67,14 @@ class Netcdf < Formula
     # find the core libs.
     args = common_args.dup << "-DNETCDF_C_LIBRARY=#{lib}"
 
-    if build.with? "cxx"
-      cxx_args = args.dup
-      cxx_args << "-DNCXX_ENABLE_TESTS=OFF" if build.without? "test"
-      resource("cxx").stage do
-        mkdir "build-cxx" do
-          system "cmake", "..", *cxx_args
-          system "make"
-          system "make", "test" if build.with? "test"
-          system "make", "install"
-        end
+    cxx_args = args.dup
+    cxx_args << "-DNCXX_ENABLE_TESTS=OFF" if build.without? "test"
+    resource("cxx").stage do
+      mkdir "build-cxx" do
+        system "cmake", "..", *cxx_args
+        system "make"
+        system "make", "test" if build.with? "test"
+        system "make", "install"
       end
     end
 
@@ -97,18 +91,16 @@ class Netcdf < Formula
       end
     end
 
-    if build.with? "cxx-compat"
-      ENV.prepend "CPPFLAGS", "-I#{include}"
-      ENV.prepend "LDFLAGS", "-L#{lib}"
-      resource("cxx-compat").stage do
-        system "./configure", "--disable-dependency-tracking",
-                              "--prefix=#{prefix}"
-        system "make"
-        system "make", "install"
-        if build.with? "test"
-          cp Dir["#{lib}/*.dylib"], "cxx/.libs/"
-          system "make", "check"
-        end
+    ENV.prepend "CPPFLAGS", "-I#{include}"
+    ENV.prepend "LDFLAGS", "-L#{lib}"
+    resource("cxx-compat").stage do
+      system "./configure", "--disable-dependency-tracking",
+                            "--prefix=#{prefix}"
+      system "make"
+      system "make", "install"
+      if build.with? "test"
+        cp Dir["#{lib}/*.dylib"], "cxx/.libs/"
+        system "make", "check"
       end
     end
   end

--- a/radx.rb
+++ b/radx.rb
@@ -4,7 +4,7 @@ class Radx < Formula
   url "https://www.eol.ucar.edu/system/files/software/radx/all-oss/radx-20160809.src_.tgz"
   version "20160809"
   sha256 "a071146df16b8abf926d35be4bc7d06b9204feeba8bbc8772858a7805bc5b92a"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class Radx < Formula
 
   depends_on "hdf5"
   depends_on "udunits"
-  depends_on "netcdf" => "with-cxx-compat"
+  depends_on "netcdf"
   depends_on "fftw"
 
   # Prevents build failure on Mac OS X 10.8 and below


### PR DESCRIPTION
netcdf is used by more than 10 formulae, which all
require different options. This makes the CI
rebuild netcdf often, slowing down version bumps.

Fortran can not be enabled because it breaks some
other packages.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
