### PR TITLE
dealii: remove netcdf "with-fortran" and "with-cxx-compat" build options

### DIFF
--- a/dealii.rb
+++ b/dealii.rb
@@ -3,7 +3,7 @@ class Dealii < Formula
   homepage "http://www.dealii.org"
   url "https://github.com/dealii/dealii/releases/download/v8.4.2/dealii-8.4.2.tar.gz"
   sha256 "ec7c00fadc9d298d1a0d16c08fb26818868410a9622c59ba624096872f3058e4"
-  revision 5
+  revision 6
 
   head "https://github.com/dealii/dealii.git"
 
@@ -32,7 +32,7 @@ class Dealii < Formula
   depends_on "hdf5"         => [:recommended] + mpidep
   depends_on "metis"        => :recommended
   depends_on "muparser"     => :recommended if MacOS.version != :mountain_lion # Undefined symbols for architecture x86_64
-  depends_on "netcdf"       => [:recommended, "with-fortran", "with-cxx-compat"]
+  depends_on "netcdf"       => :recommended
   depends_on "oce"          => :recommended
   depends_on "p4est"        => [:recommended] + openblasdep if build.with? "mpi"
   depends_on "parmetis"     => :recommended if build.with? "mpi"


### PR DESCRIPTION
netcdf no longer has a "with-fortran" option nor a "with-cxx-compat"
option since they're always enabled