### PR TITLE
vtk: improve libPythonX.Y.so detection

### DIFF
--- a/vtk.rb
+++ b/vtk.rb
@@ -146,8 +146,12 @@ class Vtk < Formula
           args << "-DPYTHON_LIBRARY='#{python_prefix}/Python'"
         elsif File.exist? "#{python_prefix}/lib/lib#{python_version}.a"
           args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/lib#{python_version}.a'"
-        else
+        elsif File.exist? "#{python_prefix}/lib/lib#{python_version}.#{dylib}"
           args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/lib#{python_version}.#{dylib}'"
+        elsif File.exist? "#{python_prefix}/lib/x86_64-linux-gnu/lib#{python_version}.#{dylib}"
+          args << "-DPYTHON_LIBRARY='#{python_prefix}/lib/x86_64-linux-gnu/lib#{python_version}.so'"
+        else
+          odie "No libpythonX.Y.{dylib|so|a} file found!"
         end
         # Set the prefix for the python bindings to the Cellar
         args << "-DVTK_INSTALL_PYTHON_MODULE_DIR='#{py_site_packages}/'"
@@ -183,15 +187,6 @@ class Vtk < Formula
       EOS
     end
 
-    if build.with? "python"
-      s += <<-EOS.undent
-
-        VTK was linked against #{Formula["python"].linked_keg.exist? ? "Homebrew's" : "your system"} copy of Python.
-        If you later decide to change Python installations, relink VTK with:
-
-          brew postinstall vtk
-      EOS
-    end
     s.empty? ? nil : s
   end
 


### PR DESCRIPTION
Under Ubunutu Xenial (but probably other distributions),
when no brewed python is installed, the actual logic
was picking up the wrong path for the libPythonX.Y.so
file.

The file is located under /usr/lib/x86_64-linux-gnu.

When no file is found, an error is now thrown,
to bail out early with a clear error message,
instead of having to read cryptic error messages
in the build log the next time this happens.

To my knowledge there seem to be no way to get this
path programatically. sysconfig.get_config_var() could
be used (checking for LIBDIR, LIBPC), but these values
seem inconsistent on OS X, so it is probably better
to handle this by trial and error.

Also, the caveats message was removed, as this is not true
anymore. We do not link against a specific python.
This should have been removed in commit
fdbb385236a86153444847eecb5831cc433eafe0
but was forgotten.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
