### PR TITLE
sundials: fix cmake audit failure

### DIFF
--- a/sundials.rb
+++ b/sundials.rb
@@ -32,7 +32,7 @@ class Sundials < Formula
   depends_on :fortran => :optional
   depends_on :mpi => [:cc, :f77, :recommended]
 
-  depends_on "cmake"
+  depends_on "cmake" => :run
   depends_on "petsc" => :optional
   depends_on "superlu_mt" => :optional
   depends_on "suite-sparse" => :recommended


### PR DESCRIPTION
cmake is indeed a runtime dependency since it's used in the test block