### PR TITLE
quake: depend on gcc@5

### DIFF
--- a/quake.rb
+++ b/quake.rb
@@ -5,36 +5,23 @@ class Quake < Formula
 
   url "http://www.cbcb.umd.edu/software/quake/downloads/quake-0.3.5.tar.gz"
   sha256 "8ded707213117463675553bb989c4c69c5d01b122945b1e265c79d7e4e34eebd"
-  revision 1
+  revision 2
 
-  bottle do
-    cellar :any
-    sha256 "b76c43979ec8370f99ced3d759c6c01e749782a510de78aea1f24312ae58dc9f" => :el_capitan
-    sha256 "2c77da904ef8c7409f0ba8fcc38100f3296f6178365de5211f76b1063b7448b8" => :yosemite
-    sha256 "23ba2a9b6fdc08bfb446243d24e7762c79319125532e53688e411b389bc811c6" => :mavericks
-    sha256 "b99dd716a06cce5859c63757c635ede84605b044904c57f1e819a71b346c7309" => :x86_64_linux
-  end
+  bottle :disable, "Test-bot cannot use the versioned gcc formulae"
 
   needs :openmp
 
   depends_on "boost"
   depends_on "jellyfish"
   depends_on "r"
+  depends_on "gcc@5" if OS.mac?
+
+  fails_with :gcc => "6"
 
   def install
     system "make", "-C", "src"
-    doc.install "LICENSE", "README"
-    bin.install %w[
-      bin/cov_model.py
-      bin/cov_model.r
-      bin/cov_model_qmer.r
-      bin/kmer_hist.r
-      bin/quake.py
-      src/build_bithash
-      src/correct
-      src/count-kmers
-      src/count-qmers
-    ]
+    bin.install Dir["{bin,src}/*"].select { |x| File.executable? x }
+    pkgshare.install %w[bin/cov_model.r bin/cov_model_qmer.r bin/kmer_hist.r]
   end
 
   test do


### PR DESCRIPTION
fails with gcc6
disable bottles
fix audit error about installing non-executables in bin