### PR TITLE
hdf5: add --without-hl option

### DIFF
--- a/hdf5.rb
+++ b/hdf5.rb
@@ -20,10 +20,11 @@ class Hdf5 < Formula
   deprecated_option "with-check" => "with-test"
 
   option "with-test", "Run build-time tests"
-  option "with-threadsafe", "Trade performance for C API thread-safety"
+  option "with-threadsafe", "Trade performance for C API thread-safety (requires --without-cxx and --without-hl)"
   option "with-fortran2003", "Compile Fortran 2003 bindings (requires --with-fortran)"
   option "with-mpi", "Compile with parallel support (unsupported with thread-safety)"
   option "without-cxx", "Disable the C++ interface"
+  option "without-hl", "Compile without high-level library"
   option "with-unsupported", "Allow unsupported combinations of configure options"
   option :cxx11
 
@@ -56,6 +57,7 @@ class Hdf5 < Formula
     ]
     args << "--enable-unsupported" if build.with? "unsupported"
     args << "--enable-threadsafe" << "--with-pthread=/usr" if build.with? "threadsafe"
+    args << "--disable-hl" if build.without? "hl"
 
     if build.with?("cxx") && build.without?("mpi")
       args << "--enable-cxx"


### PR DESCRIPTION
Necessary for threadsafe build

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
