### PR TITLE
cdo 1.7.2

### DIFF
--- a/cdo.rb
+++ b/cdo.rb
@@ -1,9 +1,9 @@
 class Cdo < Formula
   desc "Operators to manipulate and analyse climate and NWP model data"
   homepage "https://code.zmaw.de/projects/cdo"
-  url "https://code.zmaw.de/attachments/download/12070/cdo-1.7.1.tar.gz"
-  sha256 "5c24a5cb74dcf6e8b5140c67033868a5a0b641341e3adad3cb4035d5ad6e70a6"
-  revision 4
+  url "https://code.zmaw.de/attachments/download/12760/cdo-1.7.2.tar.gz"
+  sha256 "4c43eba7a95f77457bfe0d30fb82382b3b5f2b0cf90aca6f0f0a008f6cc7e697"
+  revision 5
 
   bottle do
     cellar :any

--- a/cdo.rb
+++ b/cdo.rb
@@ -3,7 +3,6 @@ class Cdo < Formula
   homepage "https://code.zmaw.de/projects/cdo"
   url "https://code.zmaw.de/attachments/download/12760/cdo-1.7.2.tar.gz"
   sha256 "4c43eba7a95f77457bfe0d30fb82382b3b5f2b0cf90aca6f0f0a008f6cc7e697"
-  revision 5
 
   bottle do
     cellar :any


### PR DESCRIPTION
The source file for 1.7.1 has been removed. This PR replaces it with 1.7.2.