### PR TITLE
opencv: fix forlinuxbrew `Iex_2_2::BaseExc::BaseExc

### DIFF
--- a/opencv.rb
+++ b/opencv.rb
@@ -78,7 +78,7 @@ class Opencv < Formula
     ]
 
     # https://github.com/Homebrew/homebrew-science/pull/5185
-    args << "-DBUILD_OPENEXR=" + (if OS.linux? then "ON" else "OFF" end)
+    args << "-DBUILD_OPENEXR=" + (OS.linux? ? "ON" : "OFF")
 
     args << "-DBUILD_TESTS=OFF" << "-DBUILD_PERF_TESTS=OFF" if build.without? "test"
     args << "-DBUILD_opencv_python=" + arg_switch("python")

--- a/opencv.rb
+++ b/opencv.rb
@@ -71,12 +71,15 @@ class Opencv < Formula
       -DBUILD_ZLIB=OFF
       -DBUILD_TIFF=OFF
       -DBUILD_PNG=OFF
-      -DBUILD_OPENEXR=ON
       -DBUILD_JASPER=OFF
       -DBUILD_JPEG=OFF
       -DJPEG_INCLUDE_DIR=#{jpeg.opt_include}
       -DJPEG_LIBRARY=#{jpeg.opt_lib}/libjpeg.#{dylib}
     ]
+
+    # https://github.com/Homebrew/homebrew-science/pull/5185
+    args << "-DBUILD_OPENEXR=" + (if OS.linux? then "ON" else "OFF" end)
+
     args << "-DBUILD_TESTS=OFF" << "-DBUILD_PERF_TESTS=OFF" if build.without? "test"
     args << "-DBUILD_opencv_python=" + arg_switch("python")
     args << "-DBUILD_opencv_java=" + arg_switch("java")

--- a/opencv.rb
+++ b/opencv.rb
@@ -71,7 +71,7 @@ class Opencv < Formula
       -DBUILD_ZLIB=OFF
       -DBUILD_TIFF=OFF
       -DBUILD_PNG=OFF
-      -DBUILD_OPENEXR=OFF
+      -DBUILD_OPENEXR=ON
       -DBUILD_JASPER=OFF
       -DBUILD_JPEG=OFF
       -DJPEG_INCLUDE_DIR=#{jpeg.opt_include}


### PR DESCRIPTION
@sjackman @iMichka 

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?


fix the month old issue https://github.com/Homebrew/homebrew-science/issues/4974

NOTE: brew audit reports the following, but unrelated to this PR:
```
brew audit --strict --online homebrew/science/opencv
homebrew/science/opencv:
  * macOS has been 64-bit only since 10.6 so universal options are deprecated.
Error: 1 problem in 1 formula
```