### PR TITLE
[DO NOT PULL] brew install opencv on bad formula gives weird error

### DIFF
--- a/opencv.rb
+++ b/opencv.rb
@@ -65,7 +65,7 @@ class Opencv < Formula
     ENV.cxx11 if build.cxx11?
     jpeg = Formula["jpeg"]
     dylib = OS.mac? ? "dylib" : "so"
-
+    -DBUILD_OPENEXR=OFF
     args = std_cmake_args + %W[
       -DCMAKE_OSX_DEPLOYMENT_TARGET=
       -DBUILD_ZLIB=OFF


### PR DESCRIPTION
@sjackman 

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

This bug is odd and very annoying: i only see it happen for linuxbrew (not mac) and homebrew-science (not homebrew-core, although haven't investigated much)

if a formula has a bug such as in this PR, it will lead to the following non-sensical result:
 
```
brew install homebrew/science/opencv
Error: No available formula with the name "homebrew/science/opencv"
==> Searching for similarly named formulae...
These similarly named formulae were found:
homebrew/science/opencv                                                                              homebrew/science/opencv3 ✔
To install one of them, run (for example):
  brew install homebrew/science/opencv
==> Searching taps...
Error: No formulae found in taps.
```

