### PR TITLE
graph-tool: Add patch resolving compile error stemming from boost::chrono and std::chrono ambiguity

### DIFF
--- a/graph-tool.rb
+++ b/graph-tool.rb
@@ -19,7 +19,7 @@ class GraphTool < Formula
   end
 
   patch do
-    url "https://git.skewed.de/count0/graph-tool/commit/aaae585f18d324d50c3e1875b9b251c5c543d19e.diff"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/3b7bcf4f4a71d8f0b3062c08c378cc20089d6b4b/graph-tool/chrono-disambiguation.diff"
     sha256 "1c1a8b8bcb3f67856d45f2707ac3924e68ecddffee909a88c8a74a547ffe43df"
   end
 

--- a/graph-tool.rb
+++ b/graph-tool.rb
@@ -18,6 +18,11 @@ class GraphTool < Formula
     depends_on "libtool" => :build
   end
 
+  patch do
+    url "https://git.skewed.de/count0/graph-tool/commit/aaae585f18d324d50c3e1875b9b251c5c543d19e.diff"
+    sha256 "1c1a8b8bcb3f67856d45f2707ac3924e68ecddffee909a88c8a74a547ffe43df"
+  end
+
   option "without-cairo", "Build without cairo support for plotting"
   option "without-gtk+3", "Build without gtk+3 support for interactive plotting"
   option "without-matplotlib", "Use a matplotlib you've installed yourself instead of a Homebrew-packaged matplotlib"


### PR DESCRIPTION
Temporarily resolves the bug keeping graph-tool from compiling on some systems/configurations as discussed in [this issue](https://github.com/Homebrew/homebrew-science/issues/5181) by @gfairchild @count0 and @geoglrb until the issue is fixed by the next release of graph-tool.

### Have you:

- [I hope, but I am a first time contributor and somewhat clueless--apologies in advance!] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [X] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [N/A, I think?] Removed the `revision` line, if any, when bumping the version number?
- [N/A, I think? ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass?
