### PR TITLE
r: Don't hint openssl

### DIFF
--- a/littler.rb
+++ b/littler.rb
@@ -5,7 +5,7 @@ class Littler < Formula
 
   url "http://dirk.eddelbuettel.com/code/littler/littler-0.2.3.tar.gz"
   sha256 "98cd741c68a5c8f65b06c96d2f56d3b44979b3990335e7869b002c005ef80ba7"
-  revision 8
+  revision 9
   head "https://github.com/eddelbuettel/littler.git"
 
   bottle do

--- a/plr.rb
+++ b/plr.rb
@@ -4,7 +4,7 @@ class Plr < Formula
   url "https://github.com/jconway/plr/archive/REL8_3_0_16.tar.gz"
   sha256 "57e2384f7b51328c9e6d92a40039cae7ac3e187ece03a1d33985b751f24bfe18"
   head "https://github.com/jconway/plr.git"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "d922fd96dfd7a57f3eda499e1a7429ce3b35a181a639ccfd5b91f992c5eb1ac8" => :el_capitan

--- a/r.rb
+++ b/r.rb
@@ -9,6 +9,7 @@ class R < Formula
   homepage "https://www.r-project.org/"
   url "https://cran.rstudio.com/src/base/R-3/R-3.3.3.tar.gz"
   sha256 "5ab768053a275084618fb669b4fbaadcc39158998a87e8465323829590bcfc6c"
+  revision 1
 
   # Do not remove executable permission from these scripts.
   # See https://github.com/Linuxbrew/linuxbrew/issues/614
@@ -111,8 +112,8 @@ class R < Formula
     args << "--without-tcltk" if build.without? "tcltk"
     args << "--without-x" if build.without? "x11"
 
-    # Help CRAN packages find gettext, readline, and openssl
-    %w[gettext readline openssl].each do |f|
+    # Help CRAN packages find gettext and readline
+    %w[gettext readline].each do |f|
       ENV.append "CPPFLAGS", "-I#{Formula[f].opt_include}"
       ENV.append "LDFLAGS", "-L#{Formula[f].opt_lib}"
     end


### PR DESCRIPTION
The openssl package is smarter than we are and we're confusing it. I
don't think there are any other popular packages that need to link to
openssl.

cf. https://github.com/jeroen/openssl/issues/39