### PR TITLE
hdf5: Remove --with-fortran2003

### DIFF
--- a/hdf5.rb
+++ b/hdf5.rb
@@ -15,13 +15,11 @@ class Hdf5 < Formula
   deprecated_option "enable-fortran" => "with-fortran"
   deprecated_option "enable-threadsafe" => "with-threadsafe"
   deprecated_option "enable-parallel" => "with-mpi"
-  deprecated_option "enable-fortran2003" => "with-fortran2003"
   deprecated_option "enable-cxx" => "with-cxx"
   deprecated_option "with-check" => "with-test"
 
   option "with-test", "Run build-time tests"
   option "with-threadsafe", "Trade performance for C API thread-safety (requires --without-cxx and --without-hl)"
-  option "with-fortran2003", "Compile Fortran 2003 bindings (requires --with-fortran)"
   option "with-mpi", "Compile with parallel support (unsupported with thread-safety)"
   option "without-cxx", "Disable the C++ interface"
   option "without-hl", "Compile without high-level library"
@@ -67,7 +65,6 @@ class Hdf5 < Formula
 
     if build.with? "fortran"
       args << "--enable-fortran"
-      args << "--enable-fortran2003" if build.with? "fortran2003"
     else
       args << "--disable-fortran"
     end


### PR DESCRIPTION
`--enable-fortran2003` does not appear to be a valid configure option any more.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
