### PR TITLE
hwloc: update 1.11.6 bottle.

### DIFF
--- a/hwloc.rb
+++ b/hwloc.rb
@@ -26,6 +26,7 @@ class Hwloc < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--enable-shared",
+                          "--enable-static",
                           "--prefix=#{prefix}",
                           "--without-x"
     system "make", "install"

--- a/hwloc.rb
+++ b/hwloc.rb
@@ -3,6 +3,7 @@ class Hwloc < Formula
   homepage "http://www.open-mpi.org/projects/hwloc/"
   url "https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.6.tar.bz2"
   sha256 "7685f7b96c7c79412c494633862612b36f8745f05f84d35ab495d38b456d87fa"
+  revision 1
 
   bottle do
     cellar :any

--- a/hwloc.rb
+++ b/hwloc.rb
@@ -1,6 +1,6 @@
 class Hwloc < Formula
   desc "Portable abstraction of the hierarchical topology of modern architectures"
-  homepage "http://www.open-mpi.org/projects/hwloc/"
+  homepage "https://www.open-mpi.org/projects/hwloc/"
   url "https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.6.tar.bz2"
   sha256 "7685f7b96c7c79412c494633862612b36f8745f05f84d35ab495d38b456d87fa"
   revision 1

--- a/hwloc.rb
+++ b/hwloc.rb
@@ -36,8 +36,10 @@ class Hwloc < Formula
   end
 
   test do
-    system ENV.cc, "-I#{include}", "-L#{lib}", "-lhwloc",
-           pkgshare/"tests/hwloc_groups.c", "-o", "test"
+    system ENV.cc, "-I#{include}", 
+      pkgshare/"tests/hwloc_groups.c",
+      "-L#{lib}", "-lhwloc",
+      "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Add --enable-static flag to configure,
so that libhwloc.a is also built.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
