### PR TITLE
repeatmasker: solved all brew audit --strict warnings 

### DIFF
--- a/repeatmasker.rb
+++ b/repeatmasker.rb
@@ -83,6 +83,6 @@ class Repeatmasker < Formula
   end
 
   test do
-    system "RepeatMasker"
+    system "#{bin}/RepeatMasker"
   end
 end

--- a/repeatmasker.rb
+++ b/repeatmasker.rb
@@ -1,9 +1,10 @@
 class Repeatmasker < Formula
+  desc "Program that screens DNA sequences for interspersed repeats"
   homepage "http://www.repeatmasker.org/"
   # tag "bioinformatics"
 
-  version "4.0.5"
   url "http://www.repeatmasker.org/RepeatMasker-open-4-0-5.tar.gz"
+  version "4.0.5"
   sha256 "e4c15c64b90d57ce2448df4c49c37529eeb725e97f3366cc90f794a4c0caeef7"
 
   bottle do
@@ -55,7 +56,11 @@ class Repeatmasker < Formula
       N
       5
       EOS
-    system "cd #{libexec} && ./configure <config.txt" if build.with? "configure"
+    if build.with? "configure"
+      Dir.chdir libexec.to_s do
+        system "./configure <config.txt"
+      end
+    end
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

---
``` brew audit --strict repeatmasker ``` gave the following warnings:
```
homebrew/science/repeatmasker:
  * `url` (line 6) should be put before `version` (line 5)
  * Formula should have a desc (Description).
  * Use the `cd` Ruby method instead of `system "cd `
```
``` brew audit repeatmasker ``` gave the following warning:
```   * Use the `cd` Ruby method instead of `system "cd ` ```

After all these warnings were resolved, and ``` brew install  repeatmasker``` and ``` brew audit --strict repeatmasker ``` run , the following error occured: ``` * fully scope test system calls e.g. system "#{bin}/RepeatMasker" ```

Then, in the second commit that error was resolved too and now ``` brew audit --strict repeatmasker ``` and ``` brew audit repeatmasker ``` show no error or warnings.

This PR resolved all these errors.