### PR TITLE
phipack: solve all "brew audit --strict" warnings

### DIFF
--- a/phipack.rb
+++ b/phipack.rb
@@ -1,6 +1,11 @@
 class Phipack < Formula
-  desc "A quick and robust genomic recombination test"
+  desc "Quick and robust genomic recombination test"
   homepage "http://www.maths.otago.ac.nz/~dbryant/software.html"
+
+  url "http://www.maths.otago.ac.nz/~dbryant/software/PhiPack.tar"
+  version "2013-03-05"
+  sha256 "bee88a90c081caac427f7bc206a59ae9a51b9d4affdb3a53750d7f9da109e193"
+
   bottle do
     cellar :any
     sha256 "1fabe869b7a87d8fec85ca7cf7ee1899d12a38994a6046f203f83026733c91a3" => :yosemite
@@ -11,10 +16,6 @@ class Phipack < Formula
 
   # doi "10.1534/genetics.105.048975"
   # tag "bioinformatics"
-
-  url "http://www.maths.otago.ac.nz/~dbryant/software/PhiPack.tar"
-  version "2013-03-05"
-  sha256 "bee88a90c081caac427f7bc206a59ae9a51b9d4affdb3a53750d7f9da109e193"
 
   def install
     system "make", "-C", "src"
@@ -27,6 +28,6 @@ class Phipack < Formula
     system "#{bin}/Phi", "-f", "#{pkgshare}/h_pylori.fasta", "-s", "#{pkgshare}/ATP6.phy"
     assert File.exist?("Phi.inf.list")
     assert File.exist?("Phi.inf.sites")
-    assert File.read("Phi.log").include?("Found 53 informative sites")
+    assert_match "Found 53 informative sites", File.read("Phi.log")
   end
 end

--- a/phipack.rb
+++ b/phipack.rb
@@ -1,8 +1,8 @@
 class Phipack < Formula
   desc "Quick and robust genomic recombination test"
-  homepage "http://www.maths.otago.ac.nz/~dbryant/software.html"
+  homepage "https://www.maths.otago.ac.nz/~dbryant/software.html"
 
-  url "http://www.maths.otago.ac.nz/~dbryant/software/PhiPack.tar"
+  url "https://www.maths.otago.ac.nz/~dbryant/software/PhiPack.tar"
   version "2013-03-05"
   sha256 "bee88a90c081caac427f7bc206a59ae9a51b9d4affdb3a53750d7f9da109e193"
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

---
 ``` brew audit --strict phipack ``` gave the following warnings:
```
  * `checksum` (line 17) should be put before `bottle block` (line 4)
  * Description shouldn't start with an indefinite article (A)
  * Use `assert_match` instead of `assert ...include?`
```

This PR solves all those warnings.