### PR TITLE
phylip: resolve all brew audit --strict warnings

### DIFF
--- a/phylip.rb
+++ b/phylip.rb
@@ -1,4 +1,5 @@
 class Phylip < Formula
+  desc "Package of programs for inferring phylogenies"
   homepage "http://evolution.genetics.washington.edu/phylip.html"
   # tag "bioinformatics"
   # doi "10.1007/BF01734359"
@@ -16,8 +17,8 @@ class Phylip < Formula
 
   def install
     cd "src" do
-      system "make -f Makefile.unx all"
-      system "make -f Makefile.unx put EXEDIR=#{libexec}"
+      system "make", "-f", "Makefile.unx", "all"
+      system "make", "-f", "Makefile.unx", "put", "EXEDIR=#{libexec}"
     end
 
     rm Dir["#{libexec}/font*"]
@@ -45,6 +46,6 @@ class Phylip < Formula
     EOF
     expected = "(((Epsilon:0.00,Delta:3.00):2.00,Gamma1:0.00):1.00,(Beta2:0.00,Beta1:0.00):2.00,Alpha2:0.00,Alpha1:0.00);"
     system "echo 'Y' | #{bin}/pars"
-    assert File.read("outtree").include?(expected)
+    assert_match expected, File.read("outtree")
   end
 end


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

---
 ``` brew audit --strict phylip ``` gave the following warnings:
```
  * Formula should have a desc (Description).
  * Use `system "make", "-f", "Makefile.unx", "all"` instead of `system "make -f Makefile.unx all"` 
  * Use `system "make", "-f", "Makefile.unx", "put", "EXEDIR=#{libexec}"` instead of `system "make -f Makefile.unx put EXEDIR=#{libexec}"` 
  * Use `assert_match` instead of `assert ...include?`
```

This PR solves all these warnings.