### PR TITLE
perf: remove brew audit warnings

### DIFF
--- a/perf.rb
+++ b/perf.rb
@@ -1,11 +1,12 @@
 class Perf < Formula
+  desc "Program to measure the performance of the predictions you submit"
   homepage "http://osmot.cs.cornell.edu/kddcup/software.html"
   url "http://osmot.cs.cornell.edu/kddcup/perf/perf.src.tar.gz"
-  sha256 "61b8d7adecc069e46c4fe9882350c69a0007c2f706be469458a9b41de0f65942"
   version "5.11"
+  sha256 "61b8d7adecc069e46c4fe9882350c69a0007c2f706be469458a9b41de0f65942"
 
   def install
-    system "rm perf"
+    File.delete "perf"
     system "make"
     bin.install "perf"
   end


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

---
``` brew audit --strict perf ``` gave the following warning:
```   
  * `version` (line 5) should be put before `checksum` (line 4)
  * Formula should have a desc (Description).
  * Use the `rm` Ruby method instead of `system "rm `
  * Use `system "rm", "perf"` instead of `system "rm perf"` 
 ```

This PR resolves those warnings.