### PR TITLE
Update to GAP 4.8.7

### DIFF
--- a/gap.rb
+++ b/gap.rb
@@ -1,9 +1,9 @@
 class Gap < Formula
   desc "System for computational discrete algebra"
-  homepage "http://www.gap-system.org/"
-  url "http://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p6_2016_11_12-14_25.tar.bz2"
-  version "4.8.6"
-  sha256 "cb401fde6b3e3c0095c55e9a92390bacd997cf5431149d53177a8cd76ab8c2a6"
+  homepage "https://www.gap-system.org/"
+  url "https://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p7_2017_03_24-21_21.tar.bz2"
+  version "4.8.7"
+  sha256 "d073cafa191df93c7d034218956058d583c5d0df05b6bb274a3952e439af9cc3"
 
   bottle do
     cellar :any


### PR DESCRIPTION
GAP 4.8.7 has been announced this Friday (http://mail.gap-system.org/pipermail/forum/2017/005468.html). This is straightforward update of the details of the new source archive and version number. It also replaces `http` by `https`.
