### PR TITLE
bump vips.rb to 8.5.2

### DIFF
--- a/vips.rb
+++ b/vips.rb
@@ -1,8 +1,8 @@
 class Vips < Formula
   desc "Image processing library"
-  homepage "http://www.vips.ecs.soton.ac.uk/"
-  url "http://www.vips.ecs.soton.ac.uk/supported/current/vips-8.4.5.tar.gz"
-  sha256 "0af73a51f53250ca240a683ba0d652003744382b78d8a10152c8f1bd019897fd"
+  homepage "https://github.com/jcupitt/libvips"
+  url "https://github.com/jcupitt/libvips/releases/download/v8.5.2/vips-8.5.2.tar.gz"
+  sha256 "282a7004384ae62fcff829489feb7179aa739f26607faf920f0148b409207ea8"
 
   bottle do
     sha256 "efb352552111d240990d7863242cb9999ef215452690e5047dd36f6fc915461f" => :sierra


### PR DESCRIPTION
libvips has a new website and now uses github for downloads, so the
source domain has changed

8.5 has lots of new stuff, detais here:

https://jcupitt.github.io/libvips/2017/03/16/What's-new-in-8.5.html

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
