### PR TITLE
bump nip2.rb to 8.5.1

### DIFF
--- a/nip2.rb
+++ b/nip2.rb
@@ -1,8 +1,8 @@
 class Nip2 < Formula
   desc "GUI for the VIPS image processing system"
-  homepage "http://www.vips.ecs.soton.ac.uk/"
-  url "http://www.vips.ecs.soton.ac.uk/supported/8.4/nip2-8.4.0.tar.gz"
-  sha256 "7a8c8b145216fbf2212de6eda4fbaff1884e3e1f8970f5e14e12a5df164e2c8a"
+  homepage "https://github.com/jcupitt/nip2"
+  url "https://github.com/jcupitt/nip2/releases/download/v8.5.1/nip2-8.5.1.tar.gz"
+  sha256 "8a3d277ae59f880b4075d8a0d4fe081e99605cbfb22f3647dafce9e24dbeb9f3"
 
   bottle do
     cellar :any
@@ -19,7 +19,6 @@ class Nip2 < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "gtk+"
-  depends_on "libxml2"
   depends_on "vips"
 
   depends_on "fftw" => :recommended


### PR DESCRIPTION
the first release of the new 8.5 series

nip2 has switched to using github to host tarballs, so the url has
changed

it now uses expat for XML, so no more libxml2 dependency

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
