### PR TITLE
OpenCV3 3.2.0: add build option --with-jpeg-turbo

### DIFF
--- a/opencv3.rb
+++ b/opencv3.rb
@@ -39,6 +39,7 @@ class Opencv3 < Formula
   option "with-cuda", "Build with CUDA v7.0+ support"
   option "with-examples", "Install C and python examples (sources)"
   option "with-java", "Build with Java support"
+  option "with-jpeg-turbo", "Build with libjpeg-turbo instead of libjpeg"
   option "with-nonfree", "Enable non-free algorithms"
   option "with-opengl", "Build with OpenGL support (must use --with-qt)"
   option "with-quicktime", "Use QuickTime for Video I/O instead of QTKit"
@@ -65,6 +66,7 @@ class Opencv3 < Formula
   depends_on "jasper" => :optional
   depends_on :java => :optional
   depends_on "jpeg"
+  depends_on "jpeg-turbo" => :optional
   depends_on "libdc1394" => :optional
   depends_on "libpng"
   depends_on "libtiff"
@@ -101,7 +103,7 @@ class Opencv3 < Formula
 
   def install
     ENV.cxx11 if build.cxx11?
-    jpeg = Formula["jpeg"]
+    jpeg = Formula[(build.with? "jpeg-turbo")? "jpeg-turbo" : "jpeg"]
     dylib = OS.mac? ? "dylib" : "so"
     with_qt = build.with?("qt")
 


### PR DESCRIPTION
libjpeg-turbo can have significant impacts in JPEG encoding/decoding performance (~30% improvement). This PR adds the `--with-jpeg-turbo` flag to OpenCV3 formula, so users can choose which JPEG library to use (original PR #4886).

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
