### PR TITLE
gmap-gsnap: Fix make check fail with ENV.deparallelize

### DIFF
--- a/gmap-gsnap.rb
+++ b/gmap-gsnap.rb
@@ -18,6 +18,7 @@ class GmapGsnap < Formula
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"
+    ENV.deparallelize
     system "make", "check"
     system "make", "install"
   end


### PR DESCRIPTION
This is the fix for the issue raised in #5110 