### PR TITLE
update vips.rb to 8.5.3

### DIFF
--- a/vips.rb
+++ b/vips.rb
@@ -1,8 +1,8 @@
 class Vips < Formula
   desc "Image processing library"
-  homepage "http://www.vips.ecs.soton.ac.uk/"
-  url "http://www.vips.ecs.soton.ac.uk/supported/current/vips-8.4.5.tar.gz"
-  sha256 "0af73a51f53250ca240a683ba0d652003744382b78d8a10152c8f1bd019897fd"
+  homepage "https://github.com/jcupitt/libvips"
+  url "https://github.com/jcupitt/libvips/releases/download/v8.5.3/vips-8.5.3.tar.gz"
+  sha256 "606ca1b33bdda57bea76b6f62f5c92d0d0f9b5904da3835d7ec6ed5b10c59fbc"
 
   bottle do
     sha256 "efb352552111d240990d7863242cb9999ef215452690e5047dd36f6fc915461f" => :sierra


### PR DESCRIPTION
just a small fix over 8.5.2 to improve stability under very heavy load

This PR obsoletes https://github.com/Homebrew/homebrew-science/pull/5399 , which has not yet been merged. I'll close that.  

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
