### PR TITLE
STACKS 1.46

### DIFF
--- a/stacks.rb
+++ b/stacks.rb
@@ -1,12 +1,11 @@
 class Stacks < Formula
   desc "Pipeline for building loci from short-read sequences"
-  homepage "http://creskolab.uoregon.edu/stacks/"
+  homepage "https://creskolab.uoregon.edu/stacks/"
   # doi "10.1111/mec.12354"
   # tag "bioinformatics
 
-  url "http://creskolab.uoregon.edu/stacks/source/stacks-1.37.tar.gz"
-  sha256 "11be4417504e4f14d64d0c022e1a9c7ced822ce529f251defbd1b83b34fc288d"
-
+  url "http://catchenlab.life.illinois.edu/stacks/source/stacks-1.46.tar.gz"
+  sha256 "45a0725483dc0c0856ad6b1f918e65d91c1f0fe7d8bf209f76b93f85c29ea28a"
   bottle do
     cellar :any_skip_relocation
     rebuild 1
@@ -24,15 +23,21 @@ class Stacks < Formula
     depends_on "google-sparsehash" => :recommended
   end
 
+  # Fix error: 'tr1/functional' file not found
+  patch :DATA
+
   needs :cxx11
+  fails_with :gcc => "4.8"
 
   def install
     ENV.libcxx
 
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
     args << "--enable-sparsehash" if build.with? "google-sparsehash"
+    args << " --disable-openmp" if build.without? "openmp"
 
     system "./configure", *args
+    system "make"
     system "make", "install"
   end
 
@@ -50,3 +55,27 @@ class Stacks < Formula
     system "#{bin}/ustacks", "--version"
   end
 end
+
+__END__
+diff --git a/src/DNANSeq.h b/src/DNANSeq.h
+index 62b5d91..9c2ff12 100644
+--- a/src/DNANSeq.h
++++ b/src/DNANSeq.h
+@@ -25,7 +25,7 @@
+ #include <limits.h>
+ 
+ #include <functional> //std::hash
+-#ifdef HAVE_SPARSEHASH
++#if 0
+ #include <tr1/functional>
+ #endif
+ 
+@@ -115,7 +115,7 @@ struct hash<DNANSeq> {
+     }
+ };
+ 
+-#ifdef HAVE_SPARSEHASH
++#if 0
+ namespace tr1 {
+ template<>
+ struct hash<DNANSeq> {


### PR DESCRIPTION
Crossposted from issue: https://github.com/Homebrew/homebrew-science/issues/5448

All I've changed in this is the download link and sha256, and I keep getting a `fatal error: 'tr1/functional' file not found`

It looks like this issue was addressed in the previous formula update https://github.com/Homebrew/homebrew-science/pull/2265 so I'm not sure why it's back or what to do now.

I have homebrew completely updated, including the gcc compiler, and am running OSX Sierra 10.12.4 

I get the same error when I try to install on a linux machine, so it doesn't seem to be just an OSX problem anymore. 


### Have you:

- [X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [X] Built your formula locally prior to submission with `brew install <formula>`?


### Updates to existing formula: have you

- [ X] Removed the `revision` line, if any, when bumping the version number?
- [ X] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass?
