### PR TITLE
r-gui: add MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/r-gui.rb
+++ b/r-gui.rb
@@ -11,6 +11,7 @@ class RGui < Formula
   homepage "https://cran.r-project.org/bin/macosx/"
   url "https://cran.r-project.org/bin/macosx/Mac-GUI-1.68.tar.gz"
   sha256 "7dff17659a69e3c492fdfc3fb765e3c9537157d50b6886236bee7ad873eb416d"
+  revision 1
 
   head "https://svn.r-project.org/R-packages/trunk/Mac-GUI"
 
@@ -37,12 +38,11 @@ class RGui < Formula
     # xcodebuild must be fed with MACOSX_DEPLOYMENT_TARGET when SDK is not
     # available for the installed system version
     # (e.g. updated Xcode/CLT to newer versions but MacOS not updated)
-    macos_version = MacOS.version.to_s
 
     xcodebuild "-target", "R", "-configuration", "Release", "SYMROOT=build",
                "HEADER_SEARCH_PATHS=#{r_opt_prefix}/R.framework/Headers",
                "OTHER_LDFLAGS=-F#{r_opt_prefix}",
-               "MACOSX_DEPLOYMENT_TARGET=#{macos_version}"
+               "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
 
     prefix.install "build/Release/R.app"
   end

--- a/r-gui.rb
+++ b/r-gui.rb
@@ -34,9 +34,15 @@ class RGui < Formula
 
     r_opt_prefix = Formula["r"].opt_prefix
 
+    # xcodebuild must be fed with MACOSX_DEPLOYMENT_TARGET when SDK is not
+    # available for the installed system version
+    # (e.g. updated Xcode/CLT to newer versions but MacOS not updated)
+    macos_version = MacOS.version.to_s
+
     xcodebuild "-target", "R", "-configuration", "Release", "SYMROOT=build",
                "HEADER_SEARCH_PATHS=#{r_opt_prefix}/R.framework/Headers",
-               "OTHER_LDFLAGS=-F#{r_opt_prefix}"
+               "OTHER_LDFLAGS=-F#{r_opt_prefix}",
+               "MACOSX_DEPLOYMENT_TARGET=#{macos_version}"
 
     prefix.install "build/Release/R.app"
   end


### PR DESCRIPTION
Following the issue discussed [here](https://github.com/Homebrew/homebrew-science/issues/5411) and suggestion for a PR to fix, here's my slight edits.

brew audit complained when passing #{MacOS.version.to_s} directly in the xcodebuild call so I stored its content in a variable similar to r_opt_prefix, to remain consistent.

### Have you:

- [X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
(there are still two errors but were already there prior to my edit and probably irrelevant here, one is hash rocket syntax on line 3 and second is request for a test do block)
- [X] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

~- [ ] Removed the `revision` line, if any, when bumping the version number?~
- [X] Added/bumped the `revision` number if the changes affect the precompiled bottles?~
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass?
