### PR TITLE
vips 8.5.4

### DIFF
--- a/vips.rb
+++ b/vips.rb
@@ -1,8 +1,8 @@
 class Vips < Formula
   desc "Image processing library"
   homepage "https://github.com/jcupitt/libvips"
-  url "https://github.com/jcupitt/libvips/releases/download/v8.5.3/vips-8.5.3.tar.gz"
-  sha256 "606ca1b33bdda57bea76b6f62f5c92d0d0f9b5904da3835d7ec6ed5b10c59fbc"
+  url "https://github.com/jcupitt/libvips/releases/download/v8.5.4/vips-8.5.4.tar.gz"
+  sha256 "fc641833a080319eb03d7e251708ebbcf87d2df507604eb4b32b19308000578e"
 
   bottle do
     sha256 "b9058ec7763e29e39ffb12eb9540215bcd496764c6c24703007400c8dcbf2441" => :sierra


### PR DESCRIPTION
don't depend on image width when setting n_lines, fixes read error with
some image widths under heavy load

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
