### PR TITLE
opencv3: fix name of cv2.so when building with Python 3

### DIFF
--- a/opencv3.rb
+++ b/opencv3.rb
@@ -136,6 +136,9 @@ class Opencv3 < Formula
     args << "-DWITH_QT=" + (with_qt ? "ON" : "OFF")
     args << "-DWITH_TBB=" + arg_switch("tbb")
     args << "-DWITH_VTK=" + arg_switch("vtk")
+    # Make sure the .so file is called cv2.so, instead of
+    # cv2.cpython-36m-darwin.so (so it can be imported).
+    args << "-DPYTHON3_CVPY_SUFFIX='.so'" if build.with? "python3"
 
     if build.include? "32-bit"
       args << "-DCMAKE_OSX_ARCHITECTURES=i386"


### PR DESCRIPTION
Setting the suffix variable overrides the weird logic
of opencv3, which tries to give the .so file the following
name: cv2.cpython-36m-darwin.so
Of course, that module can then not be imported in Python 3
with the standard "import cv2" statement.