### PR TITLE
nest: Enable concurrent Python 2 & 3 support

### DIFF
--- a/nest.rb
+++ b/nest.rb
@@ -27,7 +27,6 @@ class Nest < Formula
     depends_on "numpy"
     depends_on "scipy"
     depends_on "matplotlib"
-    depends_on "nose" => :python
   end
 
   depends_on :python3 => :optional
@@ -35,7 +34,6 @@ class Nest < Formula
     depends_on "numpy" => "with-python3"
     depends_on "scipy" => "with-python3"
     depends_on "matplotlib" => "with-python3"
-    depends_on "nose" => :python3
   end
 
   depends_on "libtool" => :run
@@ -80,8 +78,9 @@ class Nest < Formula
       ENV.prepend_create_path "PATH", buildpath/"cython/bin"
       ENV.prepend_create_path "PYTHONPATH", buildpath/"cython/lib/python#{version}/site-packages"
 
+      # Don't compile Cython to significantly reduce total build time
       resource("Cython").stage do
-        system python, *Language::Python.setup_install_args(buildpath/"cython")
+        system python, *Language::Python.setup_install_args(buildpath/"cython") + ['--no-cython-compile']
       end
 
       py_args = args.dup
@@ -104,8 +103,6 @@ class Nest < Formula
 
   def caveats
     <<-EOS.undent
-      Due to how NEST's build system is designed, concurrent Python2.x and
-      Python3.x support requires compiling NEST twice.
       `brew test` runs the PyNEST tests with each python version for which
       support has been enabled during compilation, so it might take a while.
     EOS


### PR DESCRIPTION
It is now possible to have support for both Python 2 and Python 3 in
PyNEST concurrently. Caveat: due to NEST's CMAKE build system,
this implies it needs to be fully built twice.

### Have you:

- [X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [X] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [X] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass?
