### PR TITLE
nexusformat: fix hdf4 dependency

### DIFF
--- a/nexusformat.rb
+++ b/nexusformat.rb
@@ -15,12 +15,14 @@ class Nexusformat < Formula
 
   option :cxx11
 
+  deprecated_option "hdf@4" => "hdf4"
+
   depends_on "cmake" => :build
   depends_on "libmxml"
   cxx11dep = build.cxx11? ? ["c++11"] : []
   depends_on "hdf5" => cxx11dep
   depends_on "readline" => :recommended
-  depends_on "hdf@4" => :recommended
+  depends_on "hdf4" => :recommended
   depends_on "doxygen" => :optional
 
   def install
@@ -29,7 +31,7 @@ class Nexusformat < Formula
     cmake_args << "-DENABLE_APPS=TRUE"
     cmake_args << "-DENABLE_CXX=TRUE"
     cmake_args << "-DENABLE_MXML=TRUE"
-    cmake_args << "-DENABLE_HDF4=TRUE" if build.with? "hdf@4"
+    cmake_args << "-DENABLE_HDF4=TRUE" if build.with? "hdf4"
     system "cmake", ".", *cmake_args
     system "make"
     # enable once test failures are resolved upstream


### PR DESCRIPTION
Fixes: Dependency 'hdf@4' was renamed; use new name 'hdf4'.