### PR TITLE
qrupdate: revision for new bottles

### DIFF
--- a/qrupdate.rb
+++ b/qrupdate.rb
@@ -1,8 +1,8 @@
 class Qrupdate < Formula
-  homepage "http://sourceforge.net/projects/qrupdate/"
+  homepage "https://sourceforge.net/projects/qrupdate/"
   url "https://downloads.sourceforge.net/qrupdate/qrupdate-1.1.2.tar.gz"
   sha256 "e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any


### PR DESCRIPTION
The Linux bottle is a rebuild (has a 1 in his name)
and the mac bottles are the original ones.

Commit 8fd654de62a5b3fd1993f5d44716028315469945 did
not really fix the situation.

With this commit a full new set of bottles will
be built and cleanly uploaded for Mac and Linux.


