### PR TITLE
Update swetest.rb

### DIFF
--- a/swetest.rb
+++ b/swetest.rb
@@ -1,7 +1,7 @@
 class Swetest < Formula
   homepage "http://www.astro.com/swisseph/"
-  url "http://www.astro.com/ftp/swisseph/swe_unix_src_2.06.tar.gz"
-  sha256 "bd601d5e7982926a291eb6ed50ef846f85412411ebdc2a7ae67dbd200f952289"
+  url "https://www.astro.com/ftp/swisseph/swe_unix_src_2.06.tar.gz"
+  sha256 "e2e3ac2cee53b38865b071f6d86ae0a05e0f608fbf3acc569104589d5a23576f"
 
   bottle do
     rebuild 1
@@ -11,23 +11,23 @@ class Swetest < Formula
   end
 
   resource "seasnam" do
-    url "http://www.astro.com/ftp/swisseph/ephe/seasnam.txt"
-    sha256 "88f91ac63f3ead524dc44eec9923fe0c7de73eb6c72ed9ed38575c626f026efa"
+    url "https://www.astro.com/ftp/swisseph/ephe/seasnam.txt"
+    sha256 "6388016a052de32673ab82d797be143627772d227b27d4ebb2cc8079b82ee471"
   end
   resource "sefstars" do
-    url "http://www.astro.com/ftp/swisseph/ephe/sefstars.txt"
-    sha256 "007d98f1d829ffdbd380025eaa383b4c63fc2d2ff2715d7e2586de38ce319de1"
+    url "https://www.astro.com/ftp/swisseph/ephe/sefstars.txt"
+    sha256 "3d69f4ea6d8b8be1cda81dd6a3a410ec88bb938010af6c1123180987776f69a8"
   end
   resource "seas" do
-    url "http://www.astro.com/ftp/swisseph/ephe/seas_18.se1"
+    url "https://www.astro.com/ftp/swisseph/ephe/seas_18.se1"
     sha256 "0afe3f94769b6718082411c2c4fb06bf9d1aaa6c0bc1bad8f8b8725421ef8748"
   end
   resource "semo" do
-    url "http://www.astro.com/ftp/swisseph/ephe/semo_18.se1"
+    url "https://www.astro.com/ftp/swisseph/ephe/semo_18.se1"
     sha256 "ecfa54dbf5bc0b5a9bc3e04ed28629a821e98625eacae38f4070593bba0e2980"
   end
   resource "sepl" do
-    url "http://www.astro.com/ftp/swisseph/ephe/sepl_18.se1"
+    url "https://www.astro.com/ftp/swisseph/ephe/sepl_18.se1"
     sha256 "0b7e416e3c1be9e6a0dd1d711dae7f7685793a0e7df13f76363a493dc27b6ea1"
   end
 

--- a/swetest.rb
+++ b/swetest.rb
@@ -1,5 +1,5 @@
 class Swetest < Formula
-  homepage "http://www.astro.com/swisseph/"
+  homepage "https://www.astro.com/swisseph/"
   url "https://www.astro.com/ftp/swisseph/swe_unix_src_2.06.tar.gz"
   sha256 "e2e3ac2cee53b38865b071f6d86ae0a05e0f608fbf3acc569104589d5a23576f"
 

--- a/swetest.rb
+++ b/swetest.rb
@@ -1,6 +1,6 @@
 class Swetest < Formula
   homepage "http://www.astro.com/swisseph/"
-  url "http://www.astro.com/ftp/swisseph/swe_unix_src_2.01.00.tar.gz"
+  url "http://www.astro.com/ftp/swisseph/swe_unix_src_2.06.tar.gz"
   sha256 "bd601d5e7982926a291eb6ed50ef846f85412411ebdc2a7ae67dbd200f952289"
 
   bottle do


### PR DESCRIPTION
update sourcecode url to the newest version:
http://www.astro.com/ftp/swisseph/swe_unix_src_2.06.tar.gz

### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
