### PR TITLE
update vips.rb to 8.5.5

### DIFF
--- a/vips.rb
+++ b/vips.rb
@@ -1,7 +1,7 @@
 class Vips < Formula
   desc "Image processing library"
   homepage "https://github.com/jcupitt/libvips"
-  url "https://github.com/jcupitt/libvips/releases/download/v8.5.4/vips-8.5.4.tar.gz"
+  url "https://github.com/jcupitt/libvips/releases/download/v8.5.5/vips-8.5.5.tar.gz"
   sha256 "0891af4531d6f951a16ca6d03020b73796522d5fcf7c6247f2f04c896ecded28"
 
   bottle do

--- a/vips.rb
+++ b/vips.rb
@@ -2,7 +2,7 @@ class Vips < Formula
   desc "Image processing library"
   homepage "https://github.com/jcupitt/libvips"
   url "https://github.com/jcupitt/libvips/releases/download/v8.5.4/vips-8.5.4.tar.gz"
-  sha256 "fc641833a080319eb03d7e251708ebbcf87d2df507604eb4b32b19308000578e"
+  sha256 "0891af4531d6f951a16ca6d03020b73796522d5fcf7c6247f2f04c896ecded28"
 
   bottle do
     sha256 "9dbd5f1936ae43c487564ba275af996f56f0778245062a93e93c3a05cbc060ba" => :sierra


### PR DESCRIPTION
changes:

- doc polishing
- more improvements for truncated PNG files, thanks juyunsang
- improve corrupted jpg handling, thanks juyunsang
- fix small test suite issues on os x

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
