### PR TITLE
Updated plink formula to include 1.90b4 as a stable build and 1.90b43…

### DIFF
--- a/plink2.rb
+++ b/plink2.rb
@@ -1,14 +1,11 @@
 class Plink2 < Formula
   desc "Free, open-source whole genome association analysis toolset."
   homepage "https://www.cog-genomics.org/plink2"
+  url "https://github.com/chrchang/plink-ng/archive/v1.90b4.tar.gz"
+  version "1.90b4"
+  sha256 "2ab909fc6c04062be56be86cf00ad6b3927316a34ae4ceb5fc4c250074cb3d26"
   # doi "10.1186/s13742-015-0047-8"
   # tag "bioinformatics"
-
-  stable do
-    version "1.90b4"
-    url "https://github.com/chrchang/plink-ng/archive/v1.90b4.tar.gz"
-    sha256 "2ab909fc6c04062be56be86cf00ad6b3927316a34ae4ceb5fc4c250074cb3d26"
-  end
 
   bottle do
     cellar :any
@@ -23,7 +20,7 @@ class Plink2 < Formula
   end
 
   depends_on :fortran
-  depends_on "openblas" => :optional
+  depends_on "openblas" => :optional unless OS.mac?
   depends_on "zlib"
 
   def install

--- a/plink2.rb
+++ b/plink2.rb
@@ -1,15 +1,14 @@
 class Plink2 < Formula
-  url "https://github.com/chrchang/plink-ng/archive/v1.90b3.tar.gz"
-  version "1.90b3"
+  desc "Free, open-source whole genome association analysis toolset."
+  homepage "https://www.cog-genomics.org/plink2"
   # doi "10.1186/s13742-015-0047-8"
   # tag "bioinformatics"
-  homepage "https://www.cog-genomics.org/plink2"
-  sha256 "2f4afc193c288b13af4410e4587358ee0a6f76ed7c98dd77ca1317aac28adf0d"
-  revision 1
 
-  depends_on :fortran
-  depends_on "openblas" => :optional
-  depends_on "zlib"
+  stable do
+    version "1.90b4"
+    url "https://github.com/chrchang/plink-ng/archive/v1.90b4.tar.gz"
+    sha256 "2ab909fc6c04062be56be86cf00ad6b3927316a34ae4ceb5fc4c250074cb3d26"
+  end
 
   bottle do
     cellar :any
@@ -18,15 +17,26 @@ class Plink2 < Formula
     sha256 "540b6a0f57c322040f1338655456a32c7971a3320fdc17d09fba582930c5722e" => :yosemite
   end
 
+  devel do
+    version "1.90b4.3"
+    url "https://github.com/chrchang/plink-ng.git", :revision => "49bcb9168478aad0ae047055f52ebbd9593392f3"
+  end
+
+  depends_on :fortran
+  depends_on "openblas" => :optional
+  depends_on "zlib"
+
   def install
-    mv "Makefile.std", "Makefile"
-    ln_s Formula["zlib"].opt_include, "zlib-1.2.8"
-    cflags = "-Wall -O2 -flax-vector-conversions"
-    cflags += " -I#{Formula["openblas"].opt_include}" if build.with? "openblas"
-    args = ["CFLAGS=#{cflags}", "ZLIB=-L#{Formula["zlib"].opt_lib} -lz"]
-    args << "BLASFLAGS=-L#{Formula["openblas"].opt_lib} -lopenblas" if build.with? "openblas"
-    system "make", "plink", *args
-    bin.install "plink" => "plink2"
+    Dir.chdir("1.9") do
+      mv "Makefile.std", "Makefile"
+      ln_s Formula["zlib"].opt_include, "../zlib-1.2.11"
+      cflags = "-Wall -O2 -flax-vector-conversions"
+      cflags += " -I#{Formula["openblas"].opt_include}" if build.with? "openblas"
+      args = ["CFLAGS=#{cflags}", "ZLIB=-L#{Formula["zlib"].opt_lib} -lz"]
+      args << "BLASFLAGS=-L#{Formula["openblas"].opt_lib} -lopenblas" if build.with? "openblas"
+      system "make", "plink", *args
+      bin.install "plink" => "plink2"
+    end
   end
 
   test do


### PR DESCRIPTION
I have updated the plink2 formula to build the latest tagged version (1.90 b4) as described by this link https://www.cog-genomics.org/plink2
I have also included a developer option to install 1.90b43 from git.
This is an updated version of a previous pull request https://github.com/Homebrew/homebrew-science/pull/5243 that got a but messy.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?