### PR TITLE
opencv3: set PYTHON3_EXECUTABLE

### DIFF
--- a/opencv3.rb
+++ b/opencv3.rb
@@ -203,6 +203,7 @@ class Opencv3 < Formula
       py3_config = `python3-config --configdir`.chomp
       py3_include = `python3 -c "import distutils.sysconfig as s; print(s.get_python_inc())"`.chomp
       py3_version = Language::Python.major_minor_version "python3"
+      args << "-DPYTHON3_EXECUTABLE=#{which "python3"}"
       args << "-DPYTHON3_LIBRARY=#{py3_config}/libpython#{py3_version}.#{dylib}"
       args << "-DPYTHON3_INCLUDE_DIR=#{py3_include}"
     end


### PR DESCRIPTION
This is sometimes needed when there's multiple python versions

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
