### PR TITLE
rapsearch2: rebuild bottle

### DIFF
--- a/rapsearch2.rb
+++ b/rapsearch2.rb
@@ -6,6 +6,7 @@ class Rapsearch2 < Formula
   sha256 "85db4573f4c768b6c3c73bb44ff2611ba48dc6c8d188feb40f44bf7c55de36ce"
   # tag "bioinformatics"
   # doi "10.1093/bioinformatics/btr595:"
+  revision 1
 
   bottle do
     sha256 "28f6de891fc6aff968933ca60b388388f21784c2b2d02a65e922a10043fa1ed4" => :sierra


### PR DESCRIPTION
Error: /home/linuxbrew/.linuxbrew/Cellar/rapsearch2/2.24/bin/rapsearch: error while loading shared libraries: libboost_serialization.so.1.63.0: cannot open shared object file: No such file or directory
#5791 
## Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
