### PR TITLE
slicot: make with-default-integer-8 non-optional

### DIFF
--- a/slicot.rb
+++ b/slicot.rb
@@ -1,9 +1,11 @@
 class Slicot < Formula
+  desc "Fortran 77 algorithms for computations in systems and control theory"
   homepage "http://www.slicot.org"
-  url "http://ftp.de.debian.org/debian/pool/main/s/slicot/slicot_5.0+20101122.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/slicot/slicot_5.0+20101122.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/s/slicot/slicot_5.0+20101122.orig.tar.gz"
   version "5.0+20101122"
   sha256 "fa80f7c75dab6bfaca93c3b374c774fd87876f34fba969af9133eeaea5f39a3d"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation
@@ -12,8 +14,6 @@ class Slicot < Formula
     sha256 "c9da0de7bd4de0c8e9cb030c64bf492de7b16365dbdeb11fdad3b2e900faeca3" => :yosemite
   end
 
-  option "with-default-integer-8", "Build with 8-byte-wide integer type"
-
   depends_on :fortran
 
   def install
@@ -21,16 +21,10 @@ class Slicot < Formula
       "FORTRAN=#{ENV.fc}",
       "LOADER=#{ENV.fc}",
     ]
-
-    slicotlibname = "libslicot_pic.a"
-    system "make", "lib", "OPTS=-fPIC", "SLICOTLIB=../#{slicotlibname}", *args
-    lib.install "#{slicotlibname}"
-
-    if build.with? "default-integer-8"
-      system "make", "clean"
-      slicotlibname = "libslicot64_pic.a"
-      system "make", "lib", "OPTS=-fPIC -fdefault-integer-8", "SLICOTLIB=../#{slicotlibname}", *args
-      lib.install "#{slicotlibname}"
-    end
+    system "make", "lib", "OPTS=-fPIC", "SLICOTLIB=../libslicot_pic.a", *args
+    system "make", "clean"
+    system "make", "lib", "OPTS=-fPIC -fdefault-integer-8",
+           "SLICOTLIB=../libslicot64_pic.a", *args
+    lib.install "libslicot_pic.a", "libslicot64_pic.a"
   end
 end


### PR DESCRIPTION
Always install both the regular and with-default-integer-8 libraries.