### PR TITLE
lmod: fix configuration bug

### DIFF
--- a/lmod.rb
+++ b/lmod.rb
@@ -3,6 +3,7 @@ class Lmod < Formula
   homepage "https://www.tacc.utexas.edu/research-development/tacc-projects/lmod"
   url "https://github.com/TACC/Lmod/archive/7.5.2.tar.gz"
   sha256 "f1f540fa2ddd61db31b73ac59e6e630373431b88f6630ee9254f4fdfb2e855d1"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -47,6 +48,9 @@ class Lmod < Formula
     mv Dir[prefix/"lmod/#{version}/*"], prefix
     rmdir prefix/"lmod/#{version}"
     (prefix/"lmod").install_symlink ".." => version
+    Dir[prefix/"lmod/init/*"].reject { |f| f["lmodrc.lua"] }.each do |f|
+      inreplace f, "lmod/lmod", "lmod"
+    end
   end
 
   test do


### PR DESCRIPTION
Fix bug in which sourcing any appropriate file from
`#{prefix}/lmod/lmod/init` does not make the `lmod` command `module`
available on a user's PATH.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
