### PR TITLE
vtk: remove redundant C++11 option

### DIFF
--- a/vtk.rb
+++ b/vtk.rb
@@ -19,7 +19,6 @@ class Vtk < Formula
   deprecated_option "with-qt@5.7" => "with-qt5"
   deprecated_option "with-qt5" => "with-qt"
 
-  option :cxx11
   option "with-examples",   "Compile and install various examples"
   option "with-qt-extern",  "Enable Qt4 extension via non-Homebrew external Qt4"
   option "with-tcl",        "Enable Tcl wrapping of VTK classes"
@@ -114,8 +113,6 @@ class Vtk < Formula
     args << "-DVTK_USE_SYSTEM_TIFF=ON" if build.with? "libtiff"
     args << "-DModule_vtkRenderingMatplotlib=ON" if build.with? "matplotlib"
     args << "-DVTK_LEGACY_REMOVE=ON" if build.without? "legacy"
-
-    ENV.cxx11 if build.cxx11?
 
     mkdir "build" do
       if build.with?("python3") && build.with?("python")


### PR DESCRIPTION
VTK 8 now requires C++11, so there is no need for a separate option. 

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
  - I did not attempt to address the unrelated python errors.
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
 - This doesn't change the precompiled bottle
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
