### PR TITLE
scram: Fix macOS dependency

### DIFF
--- a/scram.rb
+++ b/scram.rb
@@ -12,8 +12,7 @@ class Scram < Formula
 
   needs :cxx14
 
-  # C++14 uses GCC 5.3, which is not ABI compatible with GCC 4.8
-  depends_on :macos unless OS.mac?
+  depends_on macos: :leopard
 
   depends_on "cmake" => :build
   depends_on "boost"

--- a/scram.rb
+++ b/scram.rb
@@ -12,7 +12,7 @@ class Scram < Formula
 
   needs :cxx14
 
-  depends_on macos: :leopard
+  depends_on :macos => :leopard
 
   depends_on "cmake" => :build
   depends_on "boost"


### PR DESCRIPTION
The call to `depends_on` was invalid. Additionally, a redundant `unless OS.mac?` has been removed.
A comment about GCC compatibility has also been removed as there's no obvious connection to macOS.

Closes #5726

@iMichka @rakhimov