### PR TITLE
ampl-mp: fix linkage on linux

### DIFF
--- a/ampl-mp.rb
+++ b/ampl-mp.rb
@@ -3,6 +3,7 @@ class AmplMp < Formula
   homepage "http://www.ampl.com"
   url "https://github.com/ampl/mp/archive/3.1.0.tar.gz"
   sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
+  revision 1
 
   bottle do
     cellar :any
@@ -43,7 +44,7 @@ class AmplMp < Formula
     end
 
     resource("miniampl").stage do
-      system "make", "SHELL=/bin/bash", "CXX=#{ENV["CC"]} -std=c99", "LIBAMPL_DIR=#{prefix}", "LIBS=-L$(LIBAMPL_DIR)/lib -lasl -lm -ldl"
+      system "make", "SHELL=/bin/bash", "CXX=#{ENV["CC"]} -std=c99", "LIBAMPL_DIR=#{prefix}", "LIBS=-L$(LIBAMPL_DIR)/lib -lasl -lmp -lm -ldl"
       bin.install "bin/miniampl"
       (pkgshare/"example").install "Makefile", "README.rst", "src", "examples"
     end


### PR DESCRIPTION
### Have you:

- [X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [X] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] ~~Written a sensible test? (The best test is to compile and run a sample program.)~~

### Updates to existing formula: have you

- [ ] ~~Removed the `revision` line, if any, when bumping the version number?~~
- [X] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass?

NB: Ruby::MachO is not able to change the rpath correctly and so this formula continues to use `install_name_tool`.