### PR TITLE
Remove deprecated fails_with :llvm

### DIFF
--- a/maq.rb
+++ b/maq.rb
@@ -18,7 +18,6 @@ class Maq < Formula
   depends_on "File::Copy" => :perl
 
   fails_with :clang
-  fails_with :llvm
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/megahit.rb
+++ b/megahit.rb
@@ -15,14 +15,6 @@ class Megahit < Formula
     sha256 "40cf2e2c113eb4b1b4cfc7ad4c961bfa66e29eb0325b91bda5fffa507c968825" => :x86_64_linux
   end
 
-  fails_with :llvm do
-    build 2336
-    cause <<-EOS.undent
-    llvm-g++ does not support -mpopcnt, -std=c++0x
-    options
-    EOS
-  end
-
   needs :openmp
 
   depends_on :python

--- a/mira.rb
+++ b/mira.rb
@@ -17,7 +17,6 @@ class Mira < Formula
   depends_on "flex"
 
   fails_with :clang
-  fails_with :llvm
   fails_with :gcc
   fails_with :gcc => "4.5" do
     cause "gcc >= 4.6 is required to compile MIRA."

--- a/mrbayes.rb
+++ b/mrbayes.rb
@@ -22,11 +22,6 @@ class Mrbayes < Formula
   depends_on :mpi => [:cc, :optional]
   depends_on "beagle" => :optional
 
-  fails_with :llvm do
-    build 2336
-    cause "build hangs at calling `as`: http://sourceforge.net/tracker/index.php?func=detail&aid=3426528&group_id=129302&atid=714418"
-  end
-
   def install
     args = ["--disable-debug", "--prefix=#{prefix}"]
     args << "--with-beagle=" + ((build.with? "beagle") ? Formula["beagle"].opt_prefix : "no")

--- a/phlawd.rb
+++ b/phlawd.rb
@@ -21,10 +21,6 @@ class Phlawd < Formula
     sha256 "c51b6f732f0acb671eecdf4604fb4603fa4e5f40dad96e77d6e0f47b5475d872" => :x86_64_linux
   end
 
-  fails_with :llvm do
-    cause "The llvm compiler is not supported."
-  end
-
   # correct the makefile to look for dependencies where brew installs them
   patch :DATA
 

--- a/ray.rb
+++ b/ray.rb
@@ -24,11 +24,6 @@ class Ray < Formula
 
   depends_on :mpi => :cxx
 
-  fails_with :llvm do
-    build 2336
-    cause '"___gxx_personality_v0" ... ld: symbol(s) not found for architecture x86_64'
-  end
-
   fails_with :gcc do
     build 5666
     cause "error: wrong number of arguments specified for '__deprecated__' attribute"

--- a/shrimp.rb
+++ b/shrimp.rb
@@ -16,7 +16,6 @@ class Shrimp < Formula
   end
 
   needs :openmp
-  fails_with :llvm
 
   def install
     ENV.delete("CXXFLAGS")


### PR DESCRIPTION
- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?
- [ ] Written a sensible test? (The best test is to compile and run a sample program.)
- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?