### PR TITLE
parsnp: Fix non-executable file in bin

### DIFF
--- a/parsnp.rb
+++ b/parsnp.rb
@@ -3,6 +3,7 @@ class Parsnp < Formula
   homepage "https://github.com/marbl/parsnp"
   # tag "bioinformatics"
   # doi "10.1186/s13059-014-0524-x"
+  revision 1
   head "https://github.com/marbl/parsnp.git"
 
   if OS.mac?
@@ -15,9 +16,21 @@ class Parsnp < Formula
 
   bottle :unneeded
 
+  unless OS.mac?
+    depends_on "patchelf" => :build
+    depends_on "zlib"
+  end
+
   def install
     bin.install "parsnp"
     doc.install "README"
+    if OS.linux?
+      # Use the brewed zlib rather than the host's.
+      system "patchelf",
+        "--set-rpath", [HOMEBREW_PREFIX, Formula["zlib"].lib].join(":"),
+        "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
+        bin/"parsnp"
+    end
   end
 
   test do


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [x] Checked that the tests still pass?
