### PR TITLE
prokka: Fix non-executable file in binaries/linux/

### DIFF
--- a/prokka.rb
+++ b/prokka.rb
@@ -3,6 +3,7 @@ class Prokka < Formula
   homepage "http://www.vicbioinformatics.com/software.prokka.shtml"
   # doi "10.1093/bioinformatics/btu153"
   # tag "bioinformatics"
+  revision 1
 
   url "https://github.com/tseemann/prokka/archive/v1.12.tar.gz"
   sha256 "845e46c9db167fb1fc9d16c934b7cfd89ddfeb6cd44bd8f42204ae7b4e87adba"
@@ -25,8 +26,33 @@ class Prokka < Formula
   depends_on "barrnap" => :recommended
   depends_on "rnammer" => :optional
 
+  unless OS.mac?
+    depends_on "patchelf" => :build
+    depends_on "bzip2"
+    depends_on "zlib"
+    depends_on "libidn"
+  end
+
   def install
     prefix.install Dir["*"]
+
+    if OS.linux?
+      # Use the brewed libidn, zlib and bzip2 rather than the host's.
+      system "patchelf",
+        "--set-rpath", [HOMEBREW_PREFIX, Formula["libidn"].lib, Formula["zlib"].lib].join(":"),
+        "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
+        prefix/"binaries/linux/tbl2asn"
+
+      system "patchelf",
+        "--set-rpath", [HOMEBREW_PREFIX, Formula["bzip2"].lib, Formula["zlib"].lib].join(":"),
+        "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
+        prefix/"binaries/linux/makeblastdb"
+
+      system "patchelf",
+        "--set-rpath", [HOMEBREW_PREFIX, Formula["bzip2"].lib, Formula["zlib"].lib].join(":"),
+        "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
+        prefix/"binaries/linux/blastp"
+    end
   end
 
   def post_install


### PR DESCRIPTION
Use the brewed libidn, zlib and bzip2 rather than the host's.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
