### PR TITLE
blast: remove jpeg and png dependencies

### DIFF
--- a/blast.rb
+++ b/blast.rb
@@ -8,7 +8,7 @@ class Blast < Formula
   mirror "ftp://ftp.hgc.jp/pub/mirror/ncbi/blast/executables/blast+/2.6.0/ncbi-blast-2.6.0+-src.tar.gz"
   version "2.6.0"
   sha256 "0510e1d607d0fb4389eca50d434d5a0be787423b6850b3a4f315abc2ef19c996"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "de27d2b417b3a87eb297286b3c73baa0e0cdc169daa6d4e5cf87c3f005e1bdb3" => :sierra
@@ -23,8 +23,6 @@ class Blast < Formula
   depends_on "freetype" => :optional
   depends_on "gnutls" => :optional
   depends_on "hdf5" => :optional
-  depends_on "jpeg" => :recommended
-  depends_on "libpng" => :recommended
   depends_on "lzo" => :optional
   depends_on :mysql => :optional
   depends_on "pcre" => :recommended
@@ -49,8 +47,6 @@ class Blast < Formula
     args << (build.with?("mysql") ? "--with-mysql" : "--without-mysql")
     args << (build.with?("freetype") ? "--with-freetype=#{Formula["freetype"].opt_prefix}" : "--without-freetype")
     args << (build.with?("gnutls") ? "--with-gnutls=#{Formula["gnutls"].opt_prefix}" : "--without-gnutls")
-    args << (build.with?("jpeg")   ? "--with-jpeg=#{Formula["jpeg"].opt_prefix}" : "--without-jpeg")
-    args << (build.with?("libpng") ? "--with-png=#{Formula["libpng"].opt_prefix}" : "--without-png")
     args << (build.with?("pcre")   ? "--with-pcre=#{Formula["pcre"].opt_prefix}" : "--without-pcre")
     args << (build.with?("hdf5")   ? "--with-hdf5=#{Formula["hdf5"].opt_prefix}" : "--without-hdf5")
 


### PR DESCRIPTION
brew linkage reports that blast is never linked against these libraries.
There seem to be some code in the configure script that handles jpeg and
png, but this is then used nowhere in the code.