### PR TITLE
openalpr: depend on opencv@2

### DIFF
--- a/openalpr.rb
+++ b/openalpr.rb
@@ -4,6 +4,7 @@ class Openalpr < Formula
   url "https://github.com/openalpr/openalpr/archive/v2.3.0.tar.gz"
   sha256 "1cfcaab6f06e9984186ee19633a949158c0e2aacf9264127e2f86bd97641d6b9"
   head "https://github.com/openalpr/openalpr.git", :branch => "master"
+  revision 1
 
   bottle do
     sha256 "88834bb81c3d4c937f6875223e98e26490854f3310f7ac1524f313c6e9ed3e71" => :el_capitan
@@ -14,11 +15,10 @@ class Openalpr < Formula
   option "without-daemon", "Do not include the alpr daemon (alprd)"
 
   depends_on "cmake" => :build
-  depends_on "jpeg"
   depends_on "leptonica"
   depends_on "libtiff"
   depends_on "tesseract"
-  depends_on "opencv"
+  depends_on "opencv@2"
 
   if build.with? "daemon"
     depends_on "log4cplus"


### PR DESCRIPTION
and remove jpeg dependency: jpeg is provided by opencv@2,
and openalpr does not link against it, so there is no
reason to define that dependency here.

