### PR TITLE
rapsearch2: bump revision for boost: error: call of overloaded advance

### DIFF
--- a/rapsearch2.rb
+++ b/rapsearch2.rb
@@ -4,7 +4,7 @@ class Rapsearch2 < Formula
   url "https://downloads.sourceforge.net/project/rapsearch2/RAPSearch2.24_64bits.tar.gz"
   version "2.24"
   sha256 "85db4573f4c768b6c3c73bb44ff2611ba48dc6c8d188feb40f44bf7c55de36ce"
-  revision 1
+  revision 2
   # tag "bioinformatics"
   # doi "10.1093/bioinformatics/btr595"
 


### PR DESCRIPTION
### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
