### PR TITLE
enumlib (new formula)

### DIFF
--- a/enumlib
+++ b/enumlib
@@ -17,26 +17,21 @@ class Enumlib < Formula
 
   resource "polya" do
     # this specific version of the polya submodule is associated with
-    # the enumlib v1.0.8 release, it used to be included with the enumlib
-    # release directly, but now has its own repository
+    # the enumlib v1.0.8 release
     url "https://github.com/rosenbrockc/polya/archive/6ab2d1231829f08509c6b07679666ed7ba153c56.tar.gz"
     sha256 "20f798afddfb05ca0ad6346f37cd03960a3336fac28190abb883768ef4066e99"
   end
-
 
   def install
     ENV.deparallelize
 
     resource("symlib").stage do
-      system "cp", "-r", ".", "#{buildpath}/symlib"
+      cp_r ".", "#{buildpath}/symlib"
     end
 
     resource("polya").stage do
-      system "cp", "-r", ".", "#{buildpath}/polya"
+      cp_r ".", "#{buildpath}/polya"
     end
-    
-    # make takes either F90=gfortran or
-    # F90=ifort
 
     cd "symlib/src" do
       system "make", "F90=gfortran"
@@ -53,19 +48,25 @@ class Enumlib < Formula
       bin.install "enum.x"
       bin.install "makestr.x"
     end
-
   end
 
   test do
-    # `test do` will create, run in and delete a temporary directory.
-    #
-    # This test will fail and we won't accept that! For Homebrew/homebrew-core
-    # this will need to be a test that verifies the functionality of the
-    # software. Run the test with `brew test enumlib`. Options passed
-    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
-    #
-    # The installed folder is not in the path, so use the entire path to any
-    # executables being tested: `system "#{bin}/program", "do", "something"`.
-    system "false"
+    # using sample input provided by enumlib
+    input = "fcc
+bulk
+0.50000000     0.50000000      0.0000000        # a1 parent lattice vector
+0.50000000      0.0000000     0.50000000        # a2 parent lattice vector
+ 0.0000000     0.50000000     0.50000000        # a3 parent lattice vector
+ 2 -nary case
+    1 # Number of points in the multilattice
+ 0.0000000      0.0000000      0.0000000    0/1   # d01 d-vector
+    8 8   # Starting and ending cell sizes for search
+0.10000000E-06 # Epsilon (finite precision parameter)
+part list of labelings
+1 2 2
+1 2 2
+"
+    File.write("struct_enum.in", input)
+    system "#{bin}/enum.x"
   end
 end

--- a/enumlib
+++ b/enumlib
@@ -1,0 +1,71 @@
+class Enumlib < Formula
+  desc "Derivative structure enumeration library"
+  homepage "https://github.com/msg-byu/enumlib"
+  url "https://github.com/msg-byu/enumlib/archive/v1.0.8.tar.gz"
+  sha256 "dc82c68a0987e4c32c224b64ab03fb82397c80f789906a01994366c526c56499"
+  # doi: 10.1103/PhysRevB.77.224115
+  # doi: 10.1103/PhysRevB.80.014120
+  # doi: 10.1016/j.commatsci.2012.02.015
+
+  depends_on "gcc" => :build
+  depends_on :fortran => :build
+
+  resource "symlib" do
+    url "https://github.com/msg-byu/symlib/archive/v1.1.0.tar.gz"
+    sha256 "2dbde11031cd27c20566275fc1fca112e989e7150fa9afa5560acf483761613f"
+  end
+
+  resource "polya" do
+    # this specific version of the polya submodule is associated with
+    # the enumlib v1.0.8 release, it used to be included with the enumlib
+    # release directly, but now has its own repository
+    url "https://github.com/rosenbrockc/polya/archive/6ab2d1231829f08509c6b07679666ed7ba153c56.tar.gz"
+    sha256 "20f798afddfb05ca0ad6346f37cd03960a3336fac28190abb883768ef4066e99"
+  end
+
+
+  def install
+    ENV.deparallelize
+
+    resource("symlib").stage do
+      system "cp", "-r", ".", "#{buildpath}/symlib"
+    end
+
+    resource("polya").stage do
+      system "cp", "-r", ".", "#{buildpath}/polya"
+    end
+    
+    # make takes either F90=gfortran or
+    # F90=ifort
+
+    cd "symlib/src" do
+      system "make", "F90=gfortran"
+    end
+
+    cd "polya/fortran" do
+      system "make", "F90=gfortran"
+    end
+
+    cd "src" do
+      system "make", "F90=gfortran"
+      system "make", "F90=gfortran", "enum.x"
+      system "make", "F90=gfortran", "makestr.x"
+      bin.install "enum.x"
+      bin.install "makestr.x"
+    end
+
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test enumlib`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/enumlib
+++ b/enumlib
@@ -18,20 +18,21 @@ class Enumlib < Formula
   def install
     ENV.deparallelize
 
+    # F90 can be either gfortran or ifort
+    f90 = File.basename ENV.fc
+
     resource("symlib").stage do
       cp_r ".", "#{buildpath}/symlib"
     end
 
-    # F90 can be either gfortran or ifort
-    # could try to pick this up intelligently from $FC in future
     cd "symlib/src" do
-      system "make", "F90=gfortran"
+      system "make", "F90=#{f90}"
     end
 
     cd "src" do
-      system "make", "F90=gfortran"
-      system "make", "F90=gfortran", "enum.x"
-      system "make", "F90=gfortran", "makestr.x"
+      system "make", "F90=#{f90}"
+      system "make", "F90=#{f90}", "enum.x"
+      system "make", "F90=#{f90}", "makestr.x"
       bin.install "enum.x"
       bin.install "makestr.x"
     end

--- a/enumlib
+++ b/enumlib
@@ -15,13 +15,6 @@ class Enumlib < Formula
     sha256 "2dbde11031cd27c20566275fc1fca112e989e7150fa9afa5560acf483761613f"
   end
 
-  resource "polya" do
-    # this specific version of the polya submodule is associated with
-    # the enumlib v1.0.8 release
-    url "https://github.com/rosenbrockc/polya/archive/6ab2d1231829f08509c6b07679666ed7ba153c56.tar.gz"
-    sha256 "20f798afddfb05ca0ad6346f37cd03960a3336fac28190abb883768ef4066e99"
-  end
-
   def install
     ENV.deparallelize
 
@@ -29,15 +22,9 @@ class Enumlib < Formula
       cp_r ".", "#{buildpath}/symlib"
     end
 
-    resource("polya").stage do
-      cp_r ".", "#{buildpath}/polya"
-    end
-
+    # F90 can be either gfortran or ifort
+    # could try to pick this up intelligently from $FC in future
     cd "symlib/src" do
-      system "make", "F90=gfortran"
-    end
-
-    cd "polya/fortran" do
       system "make", "F90=gfortran"
     end
 


### PR DESCRIPTION
This formula is for the very useful structure enumeration library enumlib -- used to generate different possible permutations of crystal lattices. It's frequently used as a dependency in other codes too and is highly-cited, so I think it meets notability requirements.

~~~However, packaging is a bit tricky due to maintainers' use of git submodules. I did ask for tagged releases, which they kindly provided for the main download, but since part of the package comes from a git submodule it wasn't included in the release, and this has to be included separately as its own resource. I don't know if this meets the requirements of homebrew-science or not, so thought I'd leave it here for others to decide.~~~ Update: this has been fixed now, formula should be ready to merge.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)