### PR TITLE
Update to GAP 4.8.8

### DIFF
--- a/gap.rb
+++ b/gap.rb
@@ -1,9 +1,9 @@
 class Gap < Formula
   desc "System for computational discrete algebra"
   homepage "https://www.gap-system.org/"
-  url "https://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p7_2017_03_24-21_21.tar.bz2"
-  version "4.8.7"
-  sha256 "d073cafa191df93c7d034218956058d583c5d0df05b6bb274a3952e439af9cc3"
+  url "https://www.gap-system.org/pub/gap/gap48/tar.bz2/gap4r8p8_2017_08_20-15_12.tar.bz2"
+  version "4.8.8"
+  sha256 "16d2a809f69276ba8ff72f22d512dc7f38e182c81b15986ae78431c420bd2308"
 
   bottle do
     cellar :any


### PR DESCRIPTION
GAP 4.8.8 has been published in August (http://mail.gap-system.org/pipermail/forum/2017/005557.html). This is straightforward update of the details of the new source archive and version number.