### PR TITLE
fixed download link & updated sha256 for v. 1.4

### DIFF
--- a/trnascan.rb
+++ b/trnascan.rb
@@ -11,9 +11,9 @@ class Trnascan < Formula
   # doi "10.1093/nar/25.5.0955"
   # tag "bioinformatics"
 
-  url "http://eddylab.org/software/tRNAscan-SE/tRNAscan-SE.tar.Z"
-  version "1.23"
-  sha256 "843caf3e258a6293300513ddca7eb7dbbd2225e5baae1e5a7bcafd509f6dd550"
+  url "http://eddylab.org/software/tRNAscan-SE/tRNAscan-SE.tar.gz"
+  version "1.4"
+  sha256 "862924d869453d1c111ba02f47d4cd86c7d6896ff5ec9e975f1858682282f316"
 
   def install
     make_args = ["CFLAGS=-D_POSIX_C_SOURCE=1", "LIBDIR=#{libexec}", "BINDIR=#{bin}"]


### PR DESCRIPTION
previous version of the formula downloaded tar.Z file; `uncompress` not available on my system

### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
