### PR TITLE
mapsembler2: bump for gcc-5

### DIFF
--- a/mapsembler2.rb
+++ b/mapsembler2.rb
@@ -1,10 +1,11 @@
 class Mapsembler2 < Formula
   desc "targeted assembly software"
   homepage "https://colibread.inria.fr/software/mapsembler2/"
-  url "http://www.irisa.fr/symbiose/people/ppeterlongo/mapsembler2_2.2.4.zip"
+  url "https://www.irisa.fr/symbiose/people/ppeterlongo/mapsembler2_2.2.4.zip"
   sha256 "e25f911ada8222ad982ebaf2c1a30e5c74b81edc3b7613879299e620e77b4ec7"
   # doi "10.1186/1471-2105-13-48"
   # tag "bioinformatics"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,10 +15,6 @@ class Mapsembler2 < Formula
   fails_with :clang do
     build 703
     cause "error: no member named 'malloc' in namespace 'std'"
-  end
-
-  fails_with :gcc => "5" do
-    cause "undefined reference to `prefix_trashable[abi:cxx11]'"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula:

We will no longer accept new formula in homebrew-science, as this tap is being phased out.
Please consider submitting your formulae to https://github.com/Homebrew/homebrew-core or host it in your own tap (https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html).

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
