### PR TITLE
breseq 0.31.1

### DIFF
--- a/breseq.rb
+++ b/breseq.rb
@@ -1,8 +1,8 @@
 class Breseq < Formula
   desc "Find mutations in microbes from short reads"
   homepage "http://barricklab.org/twiki/bin/view/Lab/ToolsBacterialGenomeResequencing"
-  url "https://github.com/barricklab/breseq/releases/download/v0.30.0/breseq-0.30.0-Source.tar.gz"
-  sha256 "a5504a9bf7967a773ce28519ff4619c33f6b7f7efaf45ad8ed58273c5dea290d"
+  url "https://github.com/barricklab/breseq/releases/download/v0.31.1/breseq-0.31.1-Source.tar.gz"
+  sha256 "52471eb1c90b1b564243ad6d1c668a82a5539ef742b0badbbb9c7b3fcc2afac3"
   head "https://github.com/barricklab/breseq.git"
   # doi "10.1007/978-1-4939-0554-6_12"
   # tag "bioinformatics"


### PR DESCRIPTION
### Have you:

- [ X ] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [ X ] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ X ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ X ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula:

We will no longer accept new formula in homebrew-science, as this tap is being phased out.
Please consider submitting your formulae to https://github.com/Homebrew/homebrew-core or host it in your own tap (https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html).

### Updates to existing formula: have you

- [ X ] Removed the `revision` line, if any, when bumping the version number?
- [ X ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ X ] Not altered the `bottle` section?
- [ X ] Checked that the tests still pass?

### Comments
This edit is to update the version of breseq installed by homebrew to a version that is compatible with bowtie2 version 2.3.3.1.