### PR TITLE
Fix for #2555 (build failure on 10.10+), take two

### DIFF
--- a/spatialite-gis.rb
+++ b/spatialite-gis.rb
@@ -6,6 +6,7 @@ class SpatialiteGis < Formula
   sha1 "45508b27fbdc7166ef874ce3f79216d6c01f3c4f"
 
   depends_on "pkg-config" => :build
+  depends_on "sqlite"
   depends_on "freexl"
   depends_on "geos"
   depends_on "libharu"
@@ -31,6 +32,7 @@ class SpatialiteGis < Formula
 
     # These libs don"t get picked up by configure.
     ENV.append "LDFLAGS", "-liconv"
+    ENV.append "LDFLAGS", "-lsqlite3"
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION

_I submitted this PR with the dependency declared as “sqlite3” rather than the preferred form, simply “sqlite” – this is a resubmission of [that now-closed PR](https://github.com/Homebrew/homebrew-science/pull/6389) with the appropriate fixup._

In addition to manually adding `-liconv` to `LDFLAGS`, one needs to append `-lsqlite3` as well, in order to elide the missing-symbols link-time errors reported in Issue #2555. A `depends_on` declaration, naming the `sqlite3` formula, has likewise been added to the formula.


### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?
