### PR TITLE
Building OpenImageIO depends on ccache

### DIFF
--- a/openimageio.rb
+++ b/openimageio.rb
@@ -11,6 +11,7 @@ class Openimageio < Formula
   option "with-test", "Dowload 95MB of test images and verify Oiio (~2 min)"
   option "with-jpeg-turbo", "Build with libjpeg-turbo support, instead of libjpeg"
 
+  depends_on "ccache" => :build
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"


### PR DESCRIPTION
… adding `depends_on "ccache" => :build` to the formula allows it to build.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

