### PR TITLE
 openimageio: Dissuade build from using ccache

### DIFF
--- a/openimageio.rb
+++ b/openimageio.rb
@@ -96,6 +96,7 @@ class Openimageio < Formula
     ENV.append "MY_CMAKE_FLAGS", "-DCMAKE_FIND_FRAMEWORK=LAST"
     ENV.append "MY_CMAKE_FLAGS", "-DCMAKE_VERBOSE_MAKEFILE=ON"
     ENV.append "MY_CMAKE_FLAGS", "-DUSE_NUKE=OFF"
+    ENV.append "MY_CMAKE_FLAGS", "-DCCACHE_FOUND=CCACHE_FOUND-NOTFOUND"
 
     ENV.append "MY_CMAKE_FLAGS", "-DUSE_FFMPEG=OFF" if build.without? "ffmpeg"
     ENV.append "MY_CMAKE_FLAGS", "-DUSE_LIBRAW=OFF" if build.without? "libraw"


### PR DESCRIPTION
Defining the `cmake` variable `CCACHE_FOUND` on the command line, per the patch, suppresses the build systems’ attempt at using `ccache` (which, as of the time of writing, causes fatal compilation errors).

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?
