### PR TITLE
table2ASN: Update sha256

### DIFF
--- a/tbl2asn.rb
+++ b/tbl2asn.rb
@@ -7,10 +7,10 @@ class Tbl2asn < Formula
   version "25.3"
   if OS.mac?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/mac.tbl2asn.gz"
-    sha256 "429d63ee3c36d1f2f6322c62c6089d5ee8a8b089e5cc9373e298e017bcbbb9ec"
+    sha256 "35632173046c3b43104ec7c9652006f71ffbbbb2959d53919ad85b0bf3060581"
   elsif OS.linux?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux64.tbl2asn.gz"
-    sha256 "37fb033ef3364447d718b726f234da124d474fa22a31917d3b60458ef8294283"
+    sha256 "8cdf3401b4347f84a9b75d6b769a6d2fa062f4731902eb2545a7f969a9162d7f"
   end
 
   bottle do

--- a/tbl2asn.rb
+++ b/tbl2asn.rb
@@ -5,6 +5,7 @@ class Tbl2asn < Formula
 
   # version number is in https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/DOCUMENTATION/VERSIONS
   version "25.3"
+  revision 1
   if OS.mac?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/mac.tbl2asn.gz"
     sha256 "35632173046c3b43104ec7c9652006f71ffbbbb2959d53919ad85b0bf3060581"

--- a/tbl2asn.rb
+++ b/tbl2asn.rb
@@ -8,7 +8,7 @@ class Tbl2asn < Formula
   revision 1
   if OS.mac?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/mac.tbl2asn.gz"
-    sha256 "35632173046c3b43104ec7c9652006f71ffbbbb2959d53919ad85b0bf3060581"
+    sha256 "48471d3bde58f0d7b115b842c75bd55d3e3e8af6d7ba4cef53af643b45ebc658"
   elsif OS.linux?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux64.tbl2asn.gz"
     sha256 "8cdf3401b4347f84a9b75d6b769a6d2fa062f4731902eb2545a7f969a9162d7f"


### PR DESCRIPTION
Reflects SHA256 sums of the files currently available on NCBI. The version is the same but the files have been recently updated: https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula:

We will no longer accept new formula in homebrew-science, as this tap is being phased out.
Please consider submitting your formulae to https://github.com/Homebrew/homebrew-core or host it in your own tap (https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html).

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
