### PR TITLE
formula_renames: remove ampl-mp rename from asl

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,5 +1,4 @@
 {
-  "asl": "ampl-mp",
   "gal-sim": "galsim",
   "geant": "geant4",
   "hdf@4": "hdf4",


### PR DESCRIPTION
ampl-mp was migrated to homebrew/core so this entry triggers warnings