### PR TITLE
neuron: Dependency inter-views is optional

### DIFF
--- a/neuron.rb
+++ b/neuron.rb
@@ -26,7 +26,7 @@ class Neuron < Formula
   depends_on "bison" => :build
 
   # Dependencies of the simulator itself
-  depends_on "inter-views" => :recommended
+  depends_on "inter-views" => :optional
   depends_on :mpi => :optional
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional

--- a/neuron.rb
+++ b/neuron.rb
@@ -58,7 +58,8 @@ class Neuron < Formula
     if build.with? "inter-views"
       args << "--with-iv=#{Formula["inter-views"].opt_prefix}"
     else
-      args << "--without-iv"
+      args << "--without-x"
+      args << "--disable-rx3d"
     end
 
     # NB: autotools need to be run if building from a GitHub commit.

--- a/neuron.rb
+++ b/neuron.rb
@@ -26,7 +26,7 @@ class Neuron < Formula
   depends_on "bison" => :build
 
   # Dependencies of the simulator itself
-  depends_on "inter-views"
+  depends_on "inter-views" => :recommended
   depends_on :mpi => :optional
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
@@ -45,7 +45,7 @@ class Neuron < Formula
   patch :DATA
 
   def install
-    args = ["--with-iv=#{Formula["inter-views"].opt_prefix}"]
+    args = []
     args << "--with-paranrn" if build.with? "mpi"
     if build.with? "python3"
       args << "--with-nrnpython=python3"
@@ -53,6 +53,12 @@ class Neuron < Formula
     else
       args << "--with-nrnpython"
       python_exec = "python"
+    end
+
+    if build.with? "inter-views"
+      args << "--with-iv=#{Formula["inter-views"].opt_prefix}"
+    else
+      args << "--without-iv"
     end
 
     # NB: autotools need to be run if building from a GitHub commit.


### PR DESCRIPTION
This PR makes inter-views a "recommended" dependency of the Neuron formula, giving the option to install Neuron in an environment without X11.

If it were up to me, I would make inter-views an "optional" requirement as it is pretty archaic and most people I know use Python to visualise their data.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?