### PR TITLE
nest: ignore fail of inreplace of gcc path in nest-config

### DIFF
--- a/nest.rb
+++ b/nest.rb
@@ -102,12 +102,11 @@ class Nest < Formula
     end
 
     # Replace internally accessible gcc with externally accesible version
-    # in nest-config
-    if OS.mac? || build.without?("mpi")
-      inreplace bin/"nest-config",
-          %r{#{HOMEBREW_REPOSITORY}/Library/Homebrew/shims.*/super},
-          "#{HOMEBREW_PREFIX}/bin"
-    end
+    # in nest-config if required
+    inreplace bin/"nest-config",
+        %r{#{HOMEBREW_REPOSITORY}/Library/Homebrew/shims.*/super},
+        "#{HOMEBREW_PREFIX}/bin",
+        audit_result=FALSE
   end
 
   test do

--- a/nest.rb
+++ b/nest.rb
@@ -106,7 +106,7 @@ class Nest < Formula
     inreplace bin/"nest-config",
         %r{#{HOMEBREW_REPOSITORY}/Library/Homebrew/shims.*/super},
         "#{HOMEBREW_PREFIX}/bin",
-        audit_result=FALSE
+        FALSE
   end
 
   test do


### PR DESCRIPTION
This PR fixes problem reported on the NEST issue tracker, https://github.com/nest/nest-simulator/issues/863, where on some installations of High Sierra the gcc path doesn't need to be replaced by ignoring failures.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula:

We will no longer accept new formula in homebrew-science, as this tap is being phased out.
Please consider submitting your formulae to https://github.com/Homebrew/homebrew-core or host it in your own tap (https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html).

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?